### PR TITLE
fix: use latest golangci-lint for Go 1.25 compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
 
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

- Pin golangci-lint to latest version — v1.64.8 was built with Go 1.24 and can't lint Go 1.25 code