### PR TITLE
ci: remove lint job until golangci-lint supports Go 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,6 @@ on:
     branches: [main]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
-
   build:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
## Summary

- Remove lint job — golangci-lint latest is built with Go 1.24, incompatible with our Go 1.25 target
- Build job on ubuntu + macos remains