### PR TITLE
feat: git pull and refresh targets via g key

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ Make target runner TUI with k9s-style navigation.
 
 Discover projects in a workspace, browse their Make targets, and run them with full terminal handover.
 
-## Features (MVP)
+## Features
 
 - Recursive Makefile discovery with configurable depth and exclusions
 - Project list / target list navigation (j/k, Enter, Esc)
 - Target descriptions from `## comment` convention
-- Full terminal handover via `tea.ExecProcess` — interactive prompts work natively
+- Full terminal handover — interactive prompts work natively
+- Git pull and refresh targets with `g` key
+- README viewer with rendered markdown via `?` key
 - Status bar with exit code and duration
 
 ## Install
@@ -40,7 +42,7 @@ mkx
 | j/k, arrows | Navigate | Navigate |
 | Enter | Drill into project | Run target |
 | r | - | Run target |
-| / | Filter | Filter |
+| g | Git pull & refresh | Git pull & refresh |
 | ? | View README | View README |
 | Esc | - | Back |
 | q | Quit | Quit |

--- a/gitpull.go
+++ b/gitpull.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type gitPullFinishedMsg struct {
+	projectIndex int
+	err          error
+}
+
+type gitPullExec struct {
+	project      string
+	dir          string
+	projectIndex int
+	err          error
+}
+
+func (g *gitPullExec) Run() error {
+	sep := strings.Repeat("━", 50)
+	fmt.Printf("\n%s\n▶ git pull  (%s)\n%s\n\n", sep, g.project, sep)
+
+	c := exec.Command("git", "pull")
+	c.Dir = g.dir
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
+	g.err = c.Run()
+
+	status := "✓ pull complete"
+	if g.err != nil {
+		status = fmt.Sprintf("✗ %v", g.err)
+	}
+	fmt.Printf("\n%s\n%s\nPress Enter to return to mkx...", sep, status)
+	bufio.NewReader(os.Stdin).ReadBytes('\n')
+
+	return g.err
+}
+
+func (g *gitPullExec) SetStdin(r io.Reader)  {}
+func (g *gitPullExec) SetStdout(w io.Writer) {}
+func (g *gitPullExec) SetStderr(w io.Writer) {}
+
+func gitPull(projectIndex int, proj project) tea.Cmd {
+	gp := &gitPullExec{
+		project:      proj.Name,
+		dir:          proj.Path,
+		projectIndex: projectIndex,
+	}
+
+	return tea.Exec(gp, func(err error) tea.Msg {
+		return gitPullFinishedMsg{
+			projectIndex: gp.projectIndex,
+			err:          gp.err,
+		}
+	})
+}

--- a/model.go
+++ b/model.go
@@ -75,6 +75,19 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.flash = "No README.md found"
 		return m, nil
 
+	case gitPullFinishedMsg:
+		targets, _ := parseTargets(m.projects[msg.projectIndex].Path)
+		m.projects[msg.projectIndex].Targets = targets
+		if msg.err == nil {
+			m.flash = "Pulled & refreshed"
+		} else {
+			m.flash = fmt.Sprintf("Pull failed: %v", msg.err)
+		}
+		if m.view == viewTargets {
+			m.targetCursor = 0
+		}
+		return m, tea.EnterAltScreen
+
 	case execFinishedMsg:
 		m.lastRun = &runResult{
 			ExitCode: msg.exitCode,
@@ -123,6 +136,10 @@ func (m model) handleProjectKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.flash = ""
 			return m, viewReadme(m.projects[m.projectCursor])
 		}
+	case "g":
+		if len(m.projects) > 0 {
+			return m, gitPull(m.projectCursor, m.projects[m.projectCursor])
+		}
 	}
 	return m, nil
 }
@@ -151,6 +168,8 @@ func (m model) handleTargetKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "?":
 		m.flash = ""
 		return m, viewReadme(proj)
+	case "g":
+		return m, gitPull(m.selectedProject, proj)
 	}
 	return m, nil
 }
@@ -285,7 +304,7 @@ func (m model) renderProjectList() string {
 		s += "\n"
 	}
 
-	hint := "  Enter drill in   ? readme   q quit"
+	hint := "  Enter drill in   g pull   ? readme   q quit"
 	if m.flash != "" {
 		hint += "   " + m.flash
 	}
@@ -351,7 +370,7 @@ func (m model) renderTargetList() string {
 		s += "\n"
 	}
 
-	hint := "  / filter   r run   ? readme   Esc back"
+	hint := "  r run   g pull   ? readme   Esc back"
 	if m.lastRun != nil {
 		status := "✓"
 		if m.lastRun.ExitCode != 0 {


### PR DESCRIPTION
## Summary

- Press `g` from Project List or Target List to git pull and refresh Make targets
- Full terminal handover during pull (output visible)
- Targets re-parsed after pull, cursor reset
- Updated README with new feature and keybindings

Closes #38