### PR TITLE
chore: add MIT license and README badges

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gaetan Jaminon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # mkx
 
+[![CI](https://github.com/Gaetan-Jaminon/mkx/actions/workflows/ci.yml/badge.svg)](https://github.com/Gaetan-Jaminon/mkx/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/Gaetan-Jaminon/mkx)](https://github.com/Gaetan-Jaminon/mkx/releases/latest)
+[![Go](https://img.shields.io/github/go-mod/go-version/Gaetan-Jaminon/mkx)](https://go.dev/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 Make target runner TUI with k9s-style navigation.
 
 Discover projects in a workspace, browse their Make targets, and run them with full terminal handover.


### PR DESCRIPTION
## Summary

- Add MIT license
- Add README badges: CI status, latest release, Go version, license