### PR TITLE
feat: sort project and target tables alphabetically

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -19,9 +20,17 @@ type target struct {
 func parseTargets(projectPath string) ([]target, error) {
 	targets, err := parseWithMake(projectPath)
 	if err != nil || len(targets) == 0 {
-		return parseWithRegex(projectPath)
+		targets, err = parseWithRegex(projectPath)
 	}
-	return targets, nil
+	sortTargets(targets)
+	return targets, err
+}
+
+// sortTargets orders targets alphabetically by name, case-insensitive.
+func sortTargets(targets []target) {
+	sort.Slice(targets, func(i, j int) bool {
+		return strings.ToLower(targets[i].Name) < strings.ToLower(targets[j].Name)
+	})
 }
 
 func parseWithMake(projectPath string) ([]target, error) {

--- a/scanner.go
+++ b/scanner.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -78,6 +79,11 @@ func scanWorkspace(root string, excludes map[string]bool, maxDepth int) ([]proje
 		}
 
 		return nil
+	})
+
+	// order projects alphabetically by name, case-insensitive
+	sort.Slice(projects, func(i, j int) bool {
+		return strings.ToLower(projects[i].Name) < strings.ToLower(projects[j].Name)
 	})
 
 	return projects, err


### PR DESCRIPTION
## Summary

Both tables now display entries in alphabetical order (case-insensitive).

- **Projects** — sorted in `scanWorkspace` after the directory walk
- **Targets** — sorted in `parseTargets`, covering the initial scan and the `g`-key refresh path

Previously targets appeared in `make -pRrq` output order and projects followed walk order.