### PR TITLE
ci: run the test suite on every push and pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,5 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - run: go build -o mkx ./cmd/mkx
+      - run: make build
+      - run: make test


### PR DESCRIPTION
Closes [TAE-49](https://linear.app/taelron/issue/TAE-49/ci-runs-tests).

## What was built

CI ran `go build` only, so a broken test could reach `main` unnoticed. The workflow now builds **and** tests, through the existing Make targets rather than inlined `go` commands.

```diff
-      - run: go build -o mkx ./cmd/mkx
+      - run: make build
+      - run: make test
```

Mapped to the acceptance criteria:

| AC | How it is met |
|---|---|
| The workflow runs `go test ./...` on every push and PR | `make test` wraps `go test ./...`. The existing `on:` block already covers push-to-`main` and PRs targeting `main`, and the step runs on both matrix legs. |
| A failing test fails the workflow | `make test` propagates the non-zero exit — evidence below. |
| A make target wraps the test invocation, so the same command works locally and in CI | CI invokes `make test`, byte-for-byte the command run locally. `make build` was switched over for the same reason, which also removes the duplicated `go build -o mkx ./cmd/mkx` string that previously lived in both the Makefile and the workflow. |

Two deliberate non-changes:

- **The job name stays `build`.** It is the status check name branch protection matches on; renaming it would silently break the required check.
- **No new Make targets.** `build`, `test` and `verify` all already exist from TAE-46.

## The golden characterization oracle is covered

`TestCharacterization` — the TAE-46 golden that protects every later refactor — lives in `internal/app/`, so `go test ./...` executes it. There is no separate `make verify` step because `make test` already runs that test:

```
$ go test -v -count=1 ./... | grep -E '^--- (PASS|FAIL)'
--- PASS: TestCharacterization (0.00s)
--- PASS: TestDiscover (0.00s)
--- PASS: TestDiscoverNoMakefile (0.00s)
--- PASS: TestDiscoverProjectsComposesAndSorts (0.00s)
--- PASS: TestDiscoverProjectsKeepsProjectsWhoseTargetsFail (0.00s)
--- PASS: TestPullAndRefresh (0.00s)
--- PASS: TestReadmePath (0.00s)
--- PASS: TestRunTarget (0.00s)
--- PASS: TestTargetCommand (0.00s)
```

## Evidence

**A failing test fails the step** — temporary test added, run, then removed; not part of this diff:

```
--- FAIL: TestDeliberateFailure (0.00s)
    tmpfail_test.go:5: deliberate failure to prove make test exits non-zero
FAIL	github.com/Gaetan-Jaminon/mkx/internal/domain	0.002s
make: *** [Makefile:10: test] Error 1
EXIT CODE = 2
```

**CI run on this PR** — [run 30692601906](https://github.com/Taelron/MKX/actions/runs/30692601906), both legs SUCCESS:

```
build (ubuntu-latest)  Run make test  go test ./...
build (ubuntu-latest)  Run make test  ok  .../internal/adapter/makex  0.007s
build (ubuntu-latest)  Run make test  ok  .../internal/app            0.008s

build (macos-latest)   Run make test  go test ./...
build (macos-latest)   Run make test  ok  .../internal/adapter/makex  0.061s
build (macos-latest)   Run make test  ok  .../internal/app            0.068s
```

**This also settles an open TAE-46 assumption.** The characterization test shells out to `make -pRrq`, and TAE-46's plan (R2) argued the golden is make-version-insensitive by construction. The `macos-latest` leg passing `internal/app` is the first cross-platform run of that oracle — the assumption now has evidence behind it, not just reasoning.

## Verification handoff

Run top-to-bottom from the repo root. No inference required.

| # | Command | Purpose | Expected result |
|---|---|---|---|
| 1 | `make build` | The first step CI now runs. | Compiles; `mkx` binary at the repo root. Exit 0. |
| 2 | `make test` | The step this issue adds to CI. | `ok` for `internal/adapter/makex` and `internal/app`, `[no test files]` for the rest, no `FAIL`. Exit 0. |
| 3 | `make verify` | Confirms the golden oracle directly, independent of the full suite. | `--- PASS: TestCharacterization`. Exit 0. |

Then, in the Checks tab of this PR, confirm `build (ubuntu-latest)` and `build (macos-latest)` each show a green `make build` and `make test` step.

## Plan

No architect plan on the Linear issue — built under the trivial-issue waiver (locked scope, no design decision, no new behaviour). Reviewed inline rather than with the reviewer fleet, per the right-sizing convention for trivial PRs.
