### PR TITLE
docs: add a repo-root CLAUDE.md pointing at Linear

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# mkx
+
+Make target runner TUI with k9s-style navigation. Workspace-level rules and the collaboration model live in the parent directory's `CLAUDE.md` — this file only carries mkx-specific context.
+
+Linear is canonical. Everything below points at Linear rather than restating it; when this file and Linear disagree, Linear wins.
+
+## Current state
+
+**Phase 1 — minimum viable implementation.** Per @AI Workflow, Phase 1 ends with v1.0: an installable, usable artifact delivering the core value the spec promises. The phase is gated on that deliverable, not on a schedule.
+
+**Active milestone: M1 — Structure** (in progress) — [MkX project in Linear](https://linear.app/taelron/project/mkx-7067f8030ab4).
+
+This file is updated when the active milestone changes, typically once per milestone closure.
+
+## ADRs are Web Claude's lane
+
+Claude Code **never authors Linear documents or ADRs** (@AI Workflow). Its Linear writes are limited to issue comments and review-gated `spec-drift` issues. If implementation surfaces a conflict with an ADR, follow the drift handling protocol in @Delivery Workflow — surface it, never silently diverge, and let Web Claude record the decision.
+
+- @MkX ADR Index ([Linear](https://linear.app/taelron/document/mkx-adr-index-8558ef2aea57)) — the four accepted MkX ADRs, the `ADR-M<nnn>` numbering convention, and known future ADR topics
+
+## Baselines that govern this repo
+
+- @AI Workflow ([Linear](https://linear.app/taelron/document/ai-workflow-805fb2002fce)) — who owns which surface, phased delivery, verification by evidence
+- @Delivery Workflow ([Linear](https://linear.app/taelron/document/delivery-workflow-edab9d0993e8)) — milestone rhythm, drift handling, session entry, the PR verification handoff
+- @Hexagonal Architecture ([Linear](https://linear.app/taelron/document/hexagonal-architecture-b142001f420e)) — Go layer structure and the port/adapter contract
+- @TUI Go Conventions ([Linear](https://linear.app/taelron/document/tui-go-conventions-1aca4ef63a66)) — Bubble Tea, Lipgloss, async patterns


### PR DESCRIPTION
Closes [TAE-48](https://linear.app/taelron/issue/TAE-48/add-repo-root-claudemd).

## What was built

A repo-root `CLAUDE.md` — 26 lines, the only file in the diff. Every other Taelron repo has one; mkx did not, so sessions started with no pointer to the canonical design content.

It **points at Linear rather than restating it**, so it cannot drift into a competing source of truth. Structure follows the switchx house style (current state → lane ownership → governing baselines).

Mapped to the acceptance criteria:

| AC | How it is met |
|---|---|
| `CLAUDE.md` at repo root, checked in | Added at the repo root; confirmed not caught by `.gitignore`. |
| Points to the MkX Linear project | [MkX project](https://linear.app/taelron/project/mkx-7067f8030ab4), under **Current state**. |
| Points to the active milestone | **M1 — Structure** (in progress) — the only milestone on the project; TAE-46 through TAE-51 all sit in it. |
| Points to @AI Workflow, @Delivery Workflow, @Hexagonal Architecture, @TUI Go Conventions | All four under **Baselines that govern this repo**, each with its Linear URL and a one-line note on what it governs. |
| Points to the @MkX ADR Index | Linked under **ADRs are Web Claude's lane**. |
| Notes that MkX is in Phase 1 | "Phase 1 — minimum viable implementation", with @AI Workflow's gate condition (ends with v1.0; gated on the deliverable, not a schedule). |
| Notes that ADRs are Web Claude's lane | Its own section, quoting @AI Workflow's actual constraint: Claude Code never authors Linear documents or ADRs; its Linear writes are issue comments and review-gated `spec-drift` issues, and ADR conflicts go through the @Delivery Workflow drift protocol. |

## Evidence

**All six Linear links resolve**, checked against the API rather than eyeballed:

```
OK  https://linear.app/taelron/document/ai-workflow-805fb2002fce            -> AI Workflow
OK  https://linear.app/taelron/document/delivery-workflow-edab9d0993e8      -> Delivery Workflow
OK  https://linear.app/taelron/document/hexagonal-architecture-b142001f420e -> Hexagonal Architecture
OK  https://linear.app/taelron/document/tui-go-conventions-1aca4ef63a66     -> TUI Go Conventions
OK  https://linear.app/taelron/document/mkx-adr-index-8558ef2aea57          -> MkX ADR Index
OK  https://linear.app/taelron/project/mkx-7067f8030ab4                     -> project: MkX
```

*(The first pass reported `AI Workflow` as broken. That was the checker, not the link: the `documents` list query caps at 50 nodes and AI Workflow fell outside the page — the exact truncation trap the workspace CLAUDE.md warns about. Re-fetched directly by document ID, it resolves.)*

**No code impact** — doc-only change, full suite still green:

```
$ make build   -> go build -o mkx ./cmd/mkx                    EXIT=0
$ make test    -> ok .../internal/adapter/makex  (cached)
                  ok .../internal/app            (cached)      EXIT=0
$ make verify  -> --- PASS: TestCharacterization (0.00s)       EXIT=0
```

## Verification handoff

This issue is documentation-only, so **the Make targets below are a regression check, not a proof of the deliverable** — the deliverable itself is verified by reading the file and following its links. Run top-to-bottom from the repo root:

| # | Command | Purpose | Expected result |
|---|---|---|---|
| 1 | `make build` | Confirm the doc-only change did not disturb the build. | Compiles; `mkx` at the repo root. Exit 0. |
| 2 | `make test` | Confirm the suite is unaffected. | `ok` for `internal/adapter/makex` and `internal/app`, no `FAIL`. Exit 0. |
| 3 | `make verify` | Confirm the golden oracle is untouched. | `--- PASS: TestCharacterization`. Exit 0. |

Then the actual acceptance check, which no target can do for you:

4. Read `CLAUDE.md` and click each of the six Linear links — confirm each lands on the document it claims, and that the milestone named under **Current state** is still the active one.

## Scope note

Held strictly to the acceptance criteria. Deliberately **not** included, though the switchx CLAUDE.md has them: a module-layout quick reference and a repo-conventions section. Both are defensible additions for a repo that was just restructured by TAE-46, but neither is in this issue's ACs. Say the word if you want either and it can go in a follow-up.

## Plan

No architect plan on the Linear issue — built under the trivial-issue waiver (locked scope, no design decision, no new behaviour). Reviewed inline rather than with the reviewer fleet, per the right-sizing convention for trivial PRs.
