### PR TITLE
test: make the golden oracle fail instead of rebaselining, and assert it still exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY   := mkx
 FIXTURES := testdata/fixtures
 
-.PHONY: build test verify tidy-check run
+.PHONY: build test verify verify-guards rebaseline-golden tidy-check run
 
 build: ## Compile the mkx binary
 	go build -o $(BINARY) ./cmd/mkx
@@ -11,6 +11,12 @@ test: ## Run the full test suite
 
 verify: ## Check discovery behaviour against the committed golden
 	go test -v -run TestCharacterization ./internal/app/
+
+verify-guards: ## Prove the golden guards fail — sabotages a throwaway copy, never this tree
+	./scripts/verify-oracle-guards.sh
+
+rebaseline-golden: ## Re-anchor the golden to current behaviour — reviewed behaviour changes only
+	go test -count=1 -v -run '^TestCharacterization$$' ./internal/app/ -rebaseline
 
 tidy-check: ## Fail if go.mod/go.sum are not tidy
 	go mod tidy

--- a/README.md
+++ b/README.md
@@ -56,6 +56,40 @@ mkx
 | Esc | - | Back |
 | q | Quit | Quit |
 
+## Development
+
+### The golden oracle
+
+`testdata/fixtures.golden` records what mkx discovers over `testdata/fixtures/` — which projects, which targets, which descriptions. `TestCharacterization` compares a live run against it, so any unintended change to discovery behaviour shows up as a failing test. Run it on its own with `make verify`.
+
+The golden is **never written by the test suite**. A missing, empty, or malformed golden fails; it is not regenerated. A test that rewrites its own oracle when it fails is checking nothing.
+
+**Re-anchoring the golden** is a separate, deliberate command:
+
+```bash
+make rebaseline-golden
+```
+
+It prints every line it added and removed, so an unintended rebaseline is visible in the terminal as it happens rather than only later in a diff.
+
+Regenerating is **legitimate** when discovery behaviour changed on purpose and the change has been reviewed — extending the target metadata mkx retains, for instance, which moves every target line in the golden. Rebaseline, read the printed diff line by line, confirm each change is one you meant, and commit the golden in the same PR as the behaviour change that caused it.
+
+Regenerating is **not legitimate** as a way to make a red test green. A diff you did not expect means the code changed behaviour, not that the golden is stale.
+
+### The liveness guard
+
+`TestCharacterizationIsRegistered` fails if the oracle stops existing — deleted, renamed, skipped, or excluded by a build constraint. Without it, removing the characterization test would simply make `go test ./...` run less and stay green, and nothing would report that the only check on behaviour equivalence had gone.
+
+It reads the package source statically, so it does not depend on the characterization test running. It lives in its own file for the same reason: deleting `characterization_test.go` leaves the guard behind to complain. Deleting both defeats it — that is its acknowledged limit, and the reason it is worth noticing in review.
+
+Prove both mechanisms actually fail, rather than trusting that they would:
+
+```bash
+make verify-guards
+```
+
+It sabotages throwaway copies of the repository six ways and asserts each one goes red. Your working tree is not touched.
+
 ## Stack
 
 - [Go](https://go.dev)

--- a/internal/app/characterization_test.go
+++ b/internal/app/characterization_test.go
@@ -2,9 +2,11 @@ package app_test
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -20,6 +22,14 @@ const (
 	characterizationDepth  = 2
 )
 
+// rebaseline re-anchors the golden to current behaviour. It is deliberately a
+// flag rather than an automatic fallback: nothing in a plain `go test ./...`
+// or `make test` can set it, so the suite can never quietly rewrite the oracle
+// it is supposed to be checked against. Reach it through `make
+// rebaseline-golden`, and only for a reviewed behaviour change.
+var rebaseline = flag.Bool("rebaseline", false,
+	"rewrite the characterization golden from current behaviour (deliberate, reviewed changes only)")
+
 // TestCharacterization locks MkX's observable discovery behaviour — which
 // projects are found, and which targets and descriptions each one carries —
 // against a golden file recorded before the ADR-M001 layer extraction.
@@ -29,8 +39,11 @@ const (
 // and make-version-independent (the fixtures use plain explicit targets with
 // `## ` descriptions, nothing that varies across GNU make releases).
 //
-// A diff here means behaviour changed. The golden is not to be regenerated to
-// make this test pass.
+// A diff here means behaviour changed. This test never writes the golden: a
+// missing, unreadable, or malformed golden fails outright rather than being
+// regenerated, because a test that rewrites its own oracle on failure checks
+// nothing. Re-anchoring is `make rebaseline-golden`, and only for a reviewed
+// behaviour change.
 func TestCharacterization(t *testing.T) {
 	root, err := filepath.Abs(characterizationRoot)
 	if err != nil {
@@ -47,23 +60,129 @@ func TestCharacterization(t *testing.T) {
 		t.Fatalf("DiscoverProjects(%s): %v", root, err)
 	}
 
+	// Guard the vacuous pass. Serialization of zero projects is the empty
+	// string, which would compare equal to an empty golden — a green run that
+	// proves nothing. Discovery finding nothing is itself the failure.
+	if len(projects) == 0 {
+		t.Fatalf("DiscoverProjects(%s) found no projects; the fixtures are missing or discovery is broken", root)
+	}
+
 	got := serializeProjects(projects)
+
+	if *rebaseline {
+		rewriteGolden(t, got)
+		return
+	}
 
 	want, err := os.ReadFile(characterizationGolden)
 	if os.IsNotExist(err) {
-		if writeErr := os.WriteFile(characterizationGolden, []byte(got), 0o644); writeErr != nil {
-			t.Fatalf("writing initial golden %s: %v", characterizationGolden, writeErr)
-		}
-		t.Fatalf("golden %s did not exist; wrote it from this run. Inspect it, commit it, and re-run.", characterizationGolden)
+		t.Fatalf("golden %s does not exist. It is not written automatically. "+
+			"If this is a deliberate, reviewed behaviour change, run: make rebaseline-golden",
+			characterizationGolden)
 	}
 	if err != nil {
 		t.Fatalf("reading golden %s: %v", characterizationGolden, err)
 	}
 
+	assertGoldenWellFormed(t, string(want))
+
 	if got != string(want) {
 		t.Errorf("discovery over %s differs from %s.\n\n--- want (golden) ---\n%s\n--- got ---\n%s",
 			characterizationRoot, characterizationGolden, want, got)
 	}
+}
+
+// assertGoldenWellFormed rejects a golden that cannot be a real recording, so
+// an empty or truncated file fails as malformed rather than quietly comparing
+// equal to a degenerate result.
+func assertGoldenWellFormed(t *testing.T, golden string) {
+	t.Helper()
+
+	if strings.TrimSpace(golden) == "" {
+		t.Fatalf("golden %s is empty; it cannot be a recording of any behaviour", characterizationGolden)
+	}
+	if !strings.HasPrefix(golden, "project ") {
+		first, _, _ := strings.Cut(golden, "\n")
+		t.Fatalf("golden %s is malformed: first line is %q, want a line beginning with %q",
+			characterizationGolden, first, "project ")
+	}
+}
+
+// rewriteGolden re-anchors the golden and reports what moved, so an unintended
+// rebaseline is visible in the terminal at the moment it happens rather than
+// only later in a diff.
+func rewriteGolden(t *testing.T, got string) {
+	t.Helper()
+
+	display := strings.TrimPrefix(characterizationGolden, "../../")
+
+	old, err := os.ReadFile(characterizationGolden)
+	switch {
+	case os.IsNotExist(err):
+		fmt.Fprintf(os.Stderr, "\nREBASELINE %s (creating)\n", display)
+		fmt.Fprintf(os.Stderr, "  %d projects, %d targets recorded\n", countPrefix(got, "project "), countPrefix(got, "  target "))
+	case err != nil:
+		t.Fatalf("reading golden %s before rebaselining: %v", characterizationGolden, err)
+	default:
+		added, removed := lineDelta(string(old), got)
+		fmt.Fprintf(os.Stderr, "\nREBASELINE %s\n", display)
+		for _, l := range removed {
+			fmt.Fprintf(os.Stderr, "  - %s\n", l)
+		}
+		for _, l := range added {
+			fmt.Fprintf(os.Stderr, "  + %s\n", l)
+		}
+		if len(added) == 0 && len(removed) == 0 {
+			fmt.Fprintf(os.Stderr, "  (no change — behaviour matches the existing golden)\n")
+		} else {
+			fmt.Fprintf(os.Stderr, "%d added, %d removed\n", len(added), len(removed))
+		}
+	}
+
+	if err := os.WriteFile(characterizationGolden, []byte(got), 0o644); err != nil {
+		t.Fatalf("writing golden %s: %v", characterizationGolden, err)
+	}
+	fmt.Fprintf(os.Stderr, "This re-anchors the behaviour oracle. Commit only if the change is intended and reviewed.\n\n")
+}
+
+// lineDelta reports which lines the new recording gained and lost. The golden
+// is line-oriented and deterministically ordered, so a multiset difference is
+// enough and needs no real diff algorithm.
+func lineDelta(old, current string) (added, removed []string) {
+	count := func(s string) map[string]int {
+		m := make(map[string]int)
+		for _, line := range strings.Split(s, "\n") {
+			if line != "" {
+				m[line]++
+			}
+		}
+		return m
+	}
+	oldLines, currentLines := count(old), count(current)
+
+	for line, n := range currentLines {
+		for i := 0; i < n-oldLines[line]; i++ {
+			added = append(added, line)
+		}
+	}
+	for line, n := range oldLines {
+		for i := 0; i < n-currentLines[line]; i++ {
+			removed = append(removed, line)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+	return added, removed
+}
+
+func countPrefix(s, prefix string) int {
+	var n int
+	for _, line := range strings.Split(s, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			n++
+		}
+	}
+	return n
 }
 
 // serializeProjects renders discovery results as deterministic, path-free text.

--- a/internal/app/oracle_guard_test.go
+++ b/internal/app/oracle_guard_test.go
@@ -1,0 +1,133 @@
+package app_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// oracleTest is the test whose continued existence this file guards.
+const oracleTest = "TestCharacterization"
+
+// guardedGolden deliberately repeats the path from characterization_test.go
+// rather than referencing the constant declared there. Sharing it would make
+// this file fail to compile when that one is deleted — reporting an undefined
+// identifier instead of the guard's actual complaint, in precisely the case the
+// guard exists to explain.
+const guardedGolden = "../../testdata/fixtures.golden"
+
+// TestCharacterizationIsRegistered fails when the behaviour oracle stops
+// existing.
+//
+// Without it, deleting or renaming TestCharacterization makes `go test ./...`
+// run less and stay green: the only check on behaviour equivalence disappears
+// and nothing reports it. That is the failure this guard converts into a red
+// run.
+//
+// It is a static read of the package's source, so it does not depend on
+// TestCharacterization executing — a guard that ran only when the guarded test
+// ran would inherit the hole it exists to close. For the same reason it lives
+// in its own file: deleting characterization_test.go leaves this behind to
+// complain.
+//
+// Its limit, stated rather than engineered around: deleting both files defeats
+// it. Nothing inside the suite can prevent that. What the guard buys is turning
+// a silent one-file deletion into a deliberate two-file deletion that is
+// obvious in review.
+func TestCharacterizationIsRegistered(t *testing.T) {
+	// The golden's presence, asserted here as well as in the oracle itself, so
+	// a deleted golden is reported even if the oracle is the thing that went
+	// missing.
+	golden, err := os.ReadFile(guardedGolden)
+	if err != nil {
+		t.Errorf("golden %s: %v", guardedGolden, err)
+	} else if strings.TrimSpace(string(golden)) == "" {
+		t.Errorf("golden %s is empty", guardedGolden)
+	}
+
+	file, decl := findTestFunc(t, ".", oracleTest)
+	if decl == nil {
+		t.Fatalf("%s is not defined in any _test.go file in this package. "+
+			"The behaviour oracle has been deleted or renamed; restore it rather than removing this guard.", oracleTest)
+	}
+
+	if tag := buildConstraint(t, file); tag != "" {
+		t.Errorf("%s is excluded from normal builds by %q in %s; it would never run",
+			oracleTest, tag, filepath.Base(file))
+	}
+
+	if skip := findSkipCall(decl); skip != "" {
+		t.Errorf("%s calls t.%s, so the behaviour oracle does not run", oracleTest, skip)
+	}
+}
+
+// findTestFunc returns the path and declaration of the named function, or a nil
+// declaration if no _test.go file in dir declares it.
+func findTestFunc(t *testing.T, dir, name string) (string, *ast.FuncDecl) {
+	t.Helper()
+
+	paths, err := filepath.Glob(filepath.Join(dir, "*_test.go"))
+	if err != nil {
+		t.Fatalf("globbing %s: %v", dir, err)
+	}
+
+	fset := token.NewFileSet()
+	for _, path := range paths {
+		parsed, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		for _, d := range parsed.Decls {
+			if fn, ok := d.(*ast.FuncDecl); ok && fn.Recv == nil && fn.Name.Name == name {
+				return path, fn
+			}
+		}
+	}
+	return "", nil
+}
+
+// buildConstraint returns the build-constraint line guarding path, or "" if the
+// file carries none. Only the text above the package clause can constrain the
+// file, so that is all it reads.
+func buildConstraint(t *testing.T, path string) string {
+	t.Helper()
+
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	header, _, _ := strings.Cut(string(src), "\npackage ")
+	for _, line := range strings.Split(header, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "//go:build") || strings.HasPrefix(line, "// +build") {
+			return line
+		}
+	}
+	return ""
+}
+
+// findSkipCall returns the name of the first Skip-family call in the function
+// body, or "" if it contains none.
+func findSkipCall(fn *ast.FuncDecl) string {
+	var found string
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if found != "" {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && strings.HasPrefix(sel.Sel.Name, "Skip") {
+			found = sel.Sel.Name
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/internal/app/oracle_guard_test.go
+++ b/internal/app/oracle_guard_test.go
@@ -91,8 +91,12 @@ func findTestFunc(t *testing.T, dir, name string) (string, *ast.FuncDecl) {
 }
 
 // buildConstraint returns the build-constraint line guarding path, or "" if the
-// file carries none. Only the text above the package clause can constrain the
-// file, so that is all it reads.
+// file carries none.
+//
+// Only the text above the package clause can constrain a file, and the scan
+// stops there deliberately: build-tag syntax appearing later in the file — in a
+// raw string literal holding Go source, say — is not a constraint, and reading
+// it as one would fail a file that compiles and runs perfectly well.
 func buildConstraint(t *testing.T, path string) string {
 	t.Helper()
 
@@ -101,9 +105,11 @@ func buildConstraint(t *testing.T, path string) string {
 		t.Fatalf("reading %s: %v", path, err)
 	}
 
-	header, _, _ := strings.Cut(string(src), "\npackage ")
-	for _, line := range strings.Split(header, "\n") {
+	for _, line := range strings.Split(string(src), "\n") {
 		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "package ") {
+			return "" // reached the package clause; anything below cannot constrain the file
+		}
 		if strings.HasPrefix(line, "//go:build") || strings.HasPrefix(line, "// +build") {
 			return line
 		}

--- a/scripts/verify-oracle-guards.sh
+++ b/scripts/verify-oracle-guards.sh
@@ -20,6 +20,14 @@ ORACLE="internal/app/characterization_test.go"
 
 failures=0
 
+# The message each guard must produce. A case that goes red without its marker
+# has proved nothing.
+MISSING_GOLDEN="does not exist. It is not written automatically"
+EMPTY_GOLDEN="is empty; it cannot be a recording of any behaviour"
+ORACLE_GONE="is not defined in any _test.go file in this package"
+ORACLE_SKIPPED="calls t.Skip, so the behaviour oracle does not run"
+ORACLE_EXCLUDED="is excluded from normal builds by"
+
 # fresh_copy <name> — a pristine copy of the working tree, minus git and build output.
 fresh_copy() {
 	local dest="$WORK/$1"
@@ -28,15 +36,27 @@ fresh_copy() {
 	echo "$dest"
 }
 
-# expect_red <label> <dir> — the suite in dir must fail.
+# expect_red <label> <dir> <marker> — the suite in dir must fail, *and* say why.
+#
+# A nonzero exit is not enough. A broken copy, a module-cache hiccup, or a
+# syntax error left behind by a sabotage step also exits nonzero, and accepting
+# that would let this script report success while no guard ever fired — the
+# same class of false confidence it exists to rule out. So each case names the
+# message its guard must produce, and only that counts as a pass.
 expect_red() {
-	local label="$1" dir="$2" out
+	local label="$1" dir="$2" marker="$3" out
 	if out="$(cd "$dir" && go test -count=1 "$PKG" 2>&1)"; then
 		printf 'FAIL  %s\n      suite stayed GREEN — the guard did not trip\n' "$label"
 		failures=$((failures + 1))
-	else
-		printf 'PASS  %s\n      %s\n' "$label" "$(printf '%s' "$out" | grep -E '_test\.go:[0-9]+:' | head -1 | sed 's/^[[:space:]]*//')"
+		return
 	fi
+	if ! printf '%s' "$out" | grep -qF "$marker"; then
+		printf 'FAIL  %s\n      suite went red, but for the wrong reason — expected %s\n' "$label" "$marker"
+		printf '%s\n' "$out" | sed 's/^/        /'
+		failures=$((failures + 1))
+		return
+	fi
+	printf 'PASS  %s\n      %s\n' "$label" "$(printf '%s' "$out" | grep -F "$marker" | head -1 | sed 's/^[[:space:]]*//')"
 }
 
 # expect_absent <label> <path> — path must not have been recreated.
@@ -56,40 +76,40 @@ echo
 # --- 1. Missing golden: must fail, must not rewrite, must fail again ---------
 d="$(fresh_copy delete-golden)"
 rm "$d/$GOLDEN"
-expect_red    "missing golden, run 1" "$d"
+expect_red    "missing golden, run 1" "$d" "$MISSING_GOLDEN"
 expect_absent "missing golden, no rewrite" "$d/$GOLDEN"
-expect_red    "missing golden, run 2 (the old silent pass)" "$d"
+expect_red    "missing golden, run 2 (the old silent pass)" "$d" "$MISSING_GOLDEN"
 echo
 
 # --- 2. Empty golden: malformed, must fail ----------------------------------
 d="$(fresh_copy empty-golden)"
 : > "$d/$GOLDEN"
-expect_red "empty golden" "$d"
+expect_red "empty golden" "$d" "$EMPTY_GOLDEN"
 echo
 
 # --- 3. Oracle renamed ------------------------------------------------------
 d="$(fresh_copy rename-oracle)"
 sed -i 's/^func TestCharacterization(/func TestCharacterizationRenamed(/' "$d/$ORACLE"
-expect_red "oracle renamed" "$d"
+expect_red "oracle renamed" "$d" "$ORACLE_GONE"
 echo
 
 # --- 4. Oracle skipped ------------------------------------------------------
 d="$(fresh_copy skip-oracle)"
 sed -i 's|^func TestCharacterization(t \*testing.T) {|&\n\tt.Skip("temporarily disabled")|' "$d/$ORACLE"
-expect_red "oracle skipped" "$d"
+expect_red "oracle skipped" "$d" "$ORACLE_SKIPPED"
 echo
 
 # --- 5. Oracle excluded by a build constraint -------------------------------
 d="$(fresh_copy buildtag-oracle)"
 { echo "//go:build never"; echo; cat "$d/$ORACLE"; } > "$d/$ORACLE.tmp"
 mv "$d/$ORACLE.tmp" "$d/$ORACLE"
-expect_red "oracle excluded by //go:build" "$d"
+expect_red "oracle excluded by //go:build" "$d" "$ORACLE_EXCLUDED"
 echo
 
 # --- 6. Oracle file deleted outright ----------------------------------------
 d="$(fresh_copy delete-oracle)"
 rm "$d/$ORACLE"
-expect_red "oracle file deleted" "$d"
+expect_red "oracle file deleted" "$d" "$ORACLE_GONE"
 echo
 
 if [ "$failures" -ne 0 ]; then

--- a/scripts/verify-oracle-guards.sh
+++ b/scripts/verify-oracle-guards.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Proves the golden-oracle guards actually fail.
+#
+# A passing test suite does not demonstrate that a guard works — only that it
+# did not fire. Each case below sabotages the oracle in a throwaway copy of the
+# repository and asserts the suite goes red. Your working tree is never touched.
+#
+# Run via: make verify-guards
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PKG="./internal/app/"
+GOLDEN="testdata/fixtures.golden"
+ORACLE="internal/app/characterization_test.go"
+
+failures=0
+
+# fresh_copy <name> — a pristine copy of the working tree, minus git and build output.
+fresh_copy() {
+	local dest="$WORK/$1"
+	mkdir -p "$dest"
+	tar -C "$REPO_ROOT" --exclude=.git --exclude=dist --exclude=mkx -cf - . | tar -C "$dest" -xf -
+	echo "$dest"
+}
+
+# expect_red <label> <dir> — the suite in dir must fail.
+expect_red() {
+	local label="$1" dir="$2" out
+	if out="$(cd "$dir" && go test -count=1 "$PKG" 2>&1)"; then
+		printf 'FAIL  %s\n      suite stayed GREEN — the guard did not trip\n' "$label"
+		failures=$((failures + 1))
+	else
+		printf 'PASS  %s\n      %s\n' "$label" "$(printf '%s' "$out" | grep -E '_test\.go:[0-9]+:' | head -1 | sed 's/^[[:space:]]*//')"
+	fi
+}
+
+# expect_absent <label> <path> — path must not have been recreated.
+expect_absent() {
+	local label="$1" path="$2"
+	if [ -e "$path" ]; then
+		printf 'FAIL  %s\n      the golden was rewritten by a plain test run\n' "$label"
+		failures=$((failures + 1))
+	else
+		printf 'PASS  %s\n      the golden was not recreated\n' "$label"
+	fi
+}
+
+echo "Sabotaging throwaway copies under $WORK"
+echo
+
+# --- 1. Missing golden: must fail, must not rewrite, must fail again ---------
+d="$(fresh_copy delete-golden)"
+rm "$d/$GOLDEN"
+expect_red    "missing golden, run 1" "$d"
+expect_absent "missing golden, no rewrite" "$d/$GOLDEN"
+expect_red    "missing golden, run 2 (the old silent pass)" "$d"
+echo
+
+# --- 2. Empty golden: malformed, must fail ----------------------------------
+d="$(fresh_copy empty-golden)"
+: > "$d/$GOLDEN"
+expect_red "empty golden" "$d"
+echo
+
+# --- 3. Oracle renamed ------------------------------------------------------
+d="$(fresh_copy rename-oracle)"
+sed -i 's/^func TestCharacterization(/func TestCharacterizationRenamed(/' "$d/$ORACLE"
+expect_red "oracle renamed" "$d"
+echo
+
+# --- 4. Oracle skipped ------------------------------------------------------
+d="$(fresh_copy skip-oracle)"
+sed -i 's|^func TestCharacterization(t \*testing.T) {|&\n\tt.Skip("temporarily disabled")|' "$d/$ORACLE"
+expect_red "oracle skipped" "$d"
+echo
+
+# --- 5. Oracle excluded by a build constraint -------------------------------
+d="$(fresh_copy buildtag-oracle)"
+{ echo "//go:build never"; echo; cat "$d/$ORACLE"; } > "$d/$ORACLE.tmp"
+mv "$d/$ORACLE.tmp" "$d/$ORACLE"
+expect_red "oracle excluded by //go:build" "$d"
+echo
+
+# --- 6. Oracle file deleted outright ----------------------------------------
+d="$(fresh_copy delete-oracle)"
+rm "$d/$ORACLE"
+expect_red "oracle file deleted" "$d"
+echo
+
+if [ "$failures" -ne 0 ]; then
+	echo "$failures guard(s) failed to trip — the oracle is not protected."
+	exit 1
+fi
+
+echo "All guards tripped as required."


### PR DESCRIPTION
Closes [TAE-52](https://linear.app/taelron/issue/TAE-52/golden-oracle-fail-without-rebaselining-and-assert-liveness).

Architect plan: [comment on the issue](https://linear.app/taelron/issue/TAE-52/golden-oracle-fail-without-rebaselining-and-assert-liveness#comment-a93a223f).

## What was built

Test infrastructure only. **No application, adapter, domain, or UI code changed**, and the golden's content is untouched — TAE-47 owns that.

| AC | How it is met |
|---|---|
| A missing, unreadable, or malformed golden fails and writes nothing; running twice does not pass | The write-before-fail branch in `characterization_test.go` is deleted. Missing now fails naming `make rebaseline-golden`; unreadable already failed clean; empty or non-conforming is rejected by `assertGoldenWellFormed`. Nothing is written, so a second run fails identically. |
| Regenerating is explicit and separate, never a side effect of the suite | A `-rebaseline` flag, defaulting false, reached only through `make rebaseline-golden`. `go test ./...` and `make test` cannot set it. |
| Regenerating prints what changed | A stderr receipt listing every added and removed line, printed at the moment of the write. |
| The suite fails if the characterization test is absent or did not execute | `TestCharacterizationIsRegistered` trips on rename, delete, `t.Skip`, and `//go:build` exclusion. |
| The liveness assertion does not depend on the characterization test running | It is a static `go/ast` read of the package source. It never invokes the oracle. |
| README or Makefile documents when regenerating is legitimate | README gains *Development → the golden oracle* and *the liveness guard*; the Makefile `##` descriptions carry the one-line versions. |

Also closed, found during planning and confirmed in scope: comparison was plain string equality, so an **empty golden compared against zero discovered projects was a vacuous green** (`"" == ""`). Discovery finding no projects now fails outright.

## Evidence

**`make verify-guards` — six sabotages on throwaway copies, each must go red:**

```
PASS  missing golden, run 1
      characterization_test.go:79: golden ../../testdata/fixtures.golden does not exist.
      It is not written automatically. If this is a deliberate, reviewed behaviour change,
      run: make rebaseline-golden
PASS  missing golden, no rewrite
      the golden was not recreated
PASS  missing golden, run 2 (the old silent pass)
      characterization_test.go:79: golden ... does not exist. ...
PASS  empty golden
      characterization_test.go:87: golden ... is empty; it cannot be a recording of any behaviour
PASS  oracle renamed
      oracle_guard_test.go:54: TestCharacterization is not defined in any _test.go file in this package.
PASS  oracle skipped
      oracle_guard_test.go:64: TestCharacterization calls t.Skip, so the behaviour oracle does not run
PASS  oracle excluded by //go:build
      oracle_guard_test.go:59: TestCharacterization is excluded from normal builds by "//go:build never"
PASS  oracle file deleted
      oracle_guard_test.go:54: TestCharacterization is not defined in any _test.go file in this package.

All guards tripped as required.
```

The last case is why the guard keeps its own copy of the golden path: sharing the constant from `characterization_test.go` would make the guard fail to *compile* when that file is deleted, reporting `undefined: characterizationGolden` instead of the message above — in exactly the case the guard exists to explain.

**The rebaseline receipt matches the real golden diff.** Fixtures sabotaged in a throwaway copy (`install` given a description, a `gamma` target added):

```
REBASELINE testdata/fixtures.golden          actual diff of the golden file:
  -   target install:                          <   target install:
  +   target gamma: A brand new target         >   target install: Install the binary
  +   target install: Install the binary       >   target gamma: A brand new target
2 added, 1 removed
This re-anchors the behaviour oracle. Commit only if the change is intended and reviewed.
```

**Full suite:**

```
$ make test
ok  	github.com/Gaetan-Jaminon/mkx/internal/adapter/makex
ok  	github.com/Gaetan-Jaminon/mkx/internal/app

$ make verify
--- PASS: TestCharacterization (0.00s)
--- PASS: TestCharacterizationIsRegistered (0.00s)
```

## Two corrections to the approved plan

Both are invocation fixes found by running the thing, not design changes. Flagged because the Linear plan says otherwise.

1. **`make rebaseline-golden` needed the flag *after* the package list, and needed `-v`.** The planned `go test ... -rebaseline ./internal/app/` fails: an unrecognised flag swallows the package argument and `go test` falls back to `.`, the repo root, which has no Go files. Separately, without `-v` `go test` discards a passing package's output, so the receipt never printed — which would have defeated AC 3. The plan-session probe passed only by accident, because there the fallback `.` *was* the package under test.
2. **The guard needed its own path constant** (`guardedGolden`), for the compile-vs-message reason above.

## Verification handoff

Run top-to-bottom from the repo root. Targets 1–3 already existed; 4 and 5 are created by this issue.

| # | Command | Purpose | Expected result |
|---|---|---|---|
| 1 | `make build` | Test-only change must not disturb the build. | Compiles; `mkx` at repo root. Exit 0. |
| 2 | `make test` | Full suite including the new guard. | `ok` for `internal/adapter/makex` and `internal/app`; no `FAIL`. Exit 0. |
| 3 | `make verify` | The oracle still passes on unchanged behaviour. | `--- PASS: TestCharacterization` and `--- PASS: TestCharacterizationIsRegistered`. Exit 0. |
| 4 | `make verify-guards` | **The negative proof** — the point of this PR. Six sabotages on throwaway copies. | Eight `PASS` lines then `All guards tripped as required.` Exit 0. Then `git status --short` — your tree must be unchanged. |
| 5 | `make rebaseline-golden` | The regeneration path works and is loud. | Prints `REBASELINE testdata/fixtures.golden` and `(no change — behaviour matches the existing golden)`. Then `git diff --exit-code testdata/fixtures.golden` must exit 0 — behaviour has not changed, so the golden must come back byte-identical. |
| 6 | `make tidy-check` | No dependency drift. | Clean; exit 0. |

Step 4 is the one that matters. A green suite does not show a guard works, only that it did not fire; step 4 fires all of them.

## In-session review, and what it caught

This repo has no Claude on GitHub PR review — deliberately deferred, recorded in @MkX Design Notes and tracked as TAE-53. Three in-session reviewers ran instead. Simplicity/DRY and conventions/ADR returned no findings; both independently agreed the `guardedGolden` duplication is justified. The correctness pass found two real defects, both since fixed on this branch:

**`verify-guards` could report success while nothing was guarded** (`7ed3981`). It accepted any nonzero exit as proof a guard tripped. Demonstrated by breaking an unrelated test file in a throwaway copy:

```
PASS  <-- reported as a tripped guard
      internal/app/usecases_test.go:175:1: expected declaration, found this
```

The script could have printed *"All guards tripped as required"*, exit 0, with no guard involved — the exact false confidence it exists to rule out, in the tool this PR offers as its evidence. Each case now names the message its guard must produce; a red run missing that message is a failure with the output attached:

```
reported: FAIL  <-- correctly rejected
          suite went red, but for the wrong reason — expected is not defined in any _test.go file...
```

**`buildConstraint` scanned the whole file, not the header** (`5ec56df`). `strings.Cut(src, "\npackage ")` finds no separator when `package` is the first line, so the entire file was scanned for build-tag syntax — the opposite of the function's own doc comment. The reachable case is narrow, since a misplaced tag anywhere else is rejected by the toolchain (`misplaced compiler directive` / `misplaced +build comment`); what slips through is build-tag text inside a raw string literal, which is not a comment:

```
$ go vet ./internal/app/          (clean)
$ go test -run TestCharacterizationIsRegistered ./internal/app/
--- FAIL: TestCharacterizationIsRegistered
    oracle_guard_test.go:59: TestCharacterization is excluded from normal builds by "//go:build never"
```

A file that compiles and runs, reported as excluded. Contrived today; less so from TAE-47, which adds table tests to the parser — Go-source samples in raw strings are what those look like. The scan now stops at the package clause. Verified both directions: the raw-string case no longer trips it, a genuine leading `//go:build` still does.

Both fixes re-verified from a clean clone of this branch, not just the working tree.
