### PR TITLE
Make parser: retain phony and prerequisites, with table tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY   := mkx
 FIXTURES := testdata/fixtures
 
-.PHONY: build test verify verify-guards rebaseline-golden tidy-check run
+.PHONY: build test verify verify-parser verify-guards rebaseline-golden tidy-check run
 
 build: ## Compile the mkx binary
 	go build -o $(BINARY) ./cmd/mkx
@@ -11,6 +11,9 @@ test: ## Run the full test suite
 
 verify: ## Check discovery behaviour against the committed golden
 	go test -v -run TestCharacterization ./internal/app/
+
+verify-parser: ## Run the pure parser table tests
+	go test -v -count=1 ./internal/adapter/makex/
 
 verify-guards: ## Prove the golden guards fail — sabotages a throwaway copy, never this tree
 	./scripts/verify-oracle-guards.sh

--- a/internal/adapter/makex/makex.go
+++ b/internal/adapter/makex/makex.go
@@ -4,15 +4,16 @@
 // Discovery is the two-strategy model ratified in ADR-M002 — `make -pRrq`
 // first, a regex scan of the Makefile as the fallback when make errors or
 // yields nothing.
+//
+// This file holds the impure edges: running make, reading Makefiles, and the
+// composition of the two. The parsing itself is in parse.go and is pure.
 package makex
 
 import (
-	"bufio"
 	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -33,12 +34,18 @@ func NewRunner() *Runner {
 // Discover extracts Make targets from a project directory.
 // Tries `make -pRrq` first, falls back to regex parsing.
 func (r *Runner) Discover(ctx context.Context, projectPath string) ([]domain.Target, error) {
-	targets, err := parseWithMake(ctx, projectPath)
-	if err != nil || len(targets) == 0 {
-		targets, err = parseWithRegex(projectPath)
+	targets := parseDatabase(runDatabase(ctx, projectPath))
+	src := readMakefile(projectPath)
+
+	if len(targets) == 0 {
+		// The fallback carries its own descriptions, read from the same source.
+		targets = parseMakefile(src)
+	} else {
+		applyDescriptions(targets, descriptions(src))
 	}
+
 	sortTargets(targets)
-	return targets, err
+	return targets, nil
 }
 
 // TargetCommand returns the command that runs the named target in dir.
@@ -53,126 +60,28 @@ func sortTargets(targets []domain.Target) {
 	})
 }
 
-func parseWithMake(ctx context.Context, projectPath string) ([]domain.Target, error) {
+// runDatabase captures `make -pRrq` output for a project directory, or "" when
+// make cannot be run at all.
+func runDatabase(ctx context.Context, projectPath string) string {
 	cmd := exec.CommandContext(ctx, "make", "-pRrq", "-C", projectPath)
 	cmd.Stdin = nil
+	// The C locale is pinned per ADR-M002; the parser keys on the database's
+	// English section markers.
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+
 	out, _ := cmd.Output() // make -q exits non-zero, that's OK
-
-	var targets []domain.Target
-	seen := make(map[string]bool)
-	scanner := bufio.NewScanner(strings.NewReader(string(out)))
-	inFiles := false
-
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// skip the "# Files" section marker
-		if line == "# Files" {
-			inFiles = true
-			continue
-		}
-		if strings.HasPrefix(line, "# Not a target:") {
-			// next line is not a real target, skip it
-			if scanner.Scan() {
-				// consumed the fake target line
-			}
-			continue
-		}
-
-		if !inFiles {
-			continue
-		}
-
-		// target lines look like "name: deps"
-		if len(line) == 0 || line[0] == '#' || line[0] == '\t' || line[0] == '.' {
-			continue
-		}
-
-		idx := strings.IndexByte(line, ':')
-		if idx <= 0 {
-			continue
-		}
-
-		name := strings.TrimSpace(line[:idx])
-
-		// filter out pattern rules, variable refs, internal targets
-		if strings.ContainsAny(name, "%$") {
-			continue
-		}
-		if strings.HasPrefix(name, ".") {
-			continue
-		}
-		if seen[name] {
-			continue
-		}
-		seen[name] = true
-
-		targets = append(targets, domain.Target{Name: name})
-	}
-
-	// enrich with descriptions from the Makefile comments
-	enrichDescriptions(projectPath, targets)
-
-	return targets, nil
+	return string(out)
 }
 
-var makeTargetRe = regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_.-]*):\s*(?:.*?##\s*(.*))?$`)
-
-func parseWithRegex(projectPath string) ([]domain.Target, error) {
+// readMakefile returns the project's Makefile source, or "" when it has none.
+// `Makefile` wins over `makefile` when both exist.
+func readMakefile(projectPath string) string {
 	for _, name := range []string{"Makefile", "makefile"} {
-		f, err := os.Open(filepath.Join(projectPath, name))
+		src, err := os.ReadFile(filepath.Join(projectPath, name))
 		if err != nil {
 			continue
 		}
-		defer f.Close()
-
-		var targets []domain.Target
-		seen := make(map[string]bool)
-		scanner := bufio.NewScanner(f)
-		for scanner.Scan() {
-			matches := makeTargetRe.FindStringSubmatch(scanner.Text())
-			if matches == nil {
-				continue
-			}
-			tName := matches[1]
-			if seen[tName] {
-				continue
-			}
-			seen[tName] = true
-			targets = append(targets, domain.Target{
-				Name:        tName,
-				Description: strings.TrimSpace(matches[2]),
-			})
-		}
-		return targets, nil
+		return string(src)
 	}
-	return nil, nil
-}
-
-var descRe = regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_.-]*):\s*.*?##\s*(.*)$`)
-
-func enrichDescriptions(projectPath string, targets []domain.Target) {
-	for _, name := range []string{"Makefile", "makefile"} {
-		f, err := os.Open(filepath.Join(projectPath, name))
-		if err != nil {
-			continue
-		}
-		defer f.Close()
-
-		descs := make(map[string]string)
-		scanner := bufio.NewScanner(f)
-		for scanner.Scan() {
-			matches := descRe.FindStringSubmatch(scanner.Text())
-			if matches != nil {
-				descs[matches[1]] = strings.TrimSpace(matches[2])
-			}
-		}
-
-		for i := range targets {
-			if d, ok := descs[targets[i].Name]; ok {
-				targets[i].Description = d
-			}
-		}
-		return
-	}
+	return ""
 }

--- a/internal/adapter/makex/makex_test.go
+++ b/internal/adapter/makex/makex_test.go
@@ -12,17 +12,18 @@ const testdataDir = "../../../testdata"
 
 // TestDiscover checks the make -pRrq parse over the repository's own sample
 // Makefile: every target is found, in case-insensitive name order, each
-// carrying the description from its `## comment`.
+// carrying the description from its `## comment` and the phony status from the
+// Makefile's `.PHONY:` line — which names all eight.
 func TestDiscover(t *testing.T) {
 	want := []domain.Target{
-		{Name: "confirm", Description: "Ask for confirmation before proceeding"},
-		{Name: "fail", Description: "Always exits with error"},
-		{Name: "greet", Description: "Greet someone (usage: make greet NAME=Alice)"},
-		{Name: "hello", Description: "Print a greeting"},
-		{Name: "long-running", Description: "Simulate a long task (5s)"},
-		{Name: "multiline", Description: "Print lots of output"},
-		{Name: "no-desc", Description: ""},
-		{Name: "prompt", Description: "Ask for user input"},
+		{Name: "confirm", Description: "Ask for confirmation before proceeding", Phony: domain.PhonyYes},
+		{Name: "fail", Description: "Always exits with error", Phony: domain.PhonyYes},
+		{Name: "greet", Description: "Greet someone (usage: make greet NAME=Alice)", Phony: domain.PhonyYes},
+		{Name: "hello", Description: "Print a greeting", Phony: domain.PhonyYes},
+		{Name: "long-running", Description: "Simulate a long task (5s)", Phony: domain.PhonyYes},
+		{Name: "multiline", Description: "Print lots of output", Phony: domain.PhonyYes},
+		{Name: "no-desc", Description: "", Phony: domain.PhonyYes},
+		{Name: "prompt", Description: "Ask for user input", Phony: domain.PhonyYes},
 	}
 
 	got, err := makex.NewRunner().Discover(context.Background(), testdataDir)
@@ -34,10 +35,28 @@ func TestDiscover(t *testing.T) {
 		t.Fatalf("got %d targets, want %d: %+v", len(got), len(want), got)
 	}
 	for i := range want {
-		if got[i] != want[i] {
+		if !equalTarget(got[i], want[i]) {
 			t.Errorf("target %d: got %+v, want %+v", i, got[i], want[i])
 		}
 	}
+}
+
+// equalTarget compares two targets field by field. domain.Target holds a slice
+// and so is no longer comparable with ==; a hand-rolled helper keeps the test
+// honest without adding a module dependency for it.
+func equalTarget(a, b domain.Target) bool {
+	if a.Name != b.Name || a.Description != b.Description || a.Phony != b.Phony {
+		return false
+	}
+	if len(a.Prerequisites) != len(b.Prerequisites) {
+		return false
+	}
+	for i := range a.Prerequisites {
+		if a.Prerequisites[i] != b.Prerequisites[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // TestDiscoverNoMakefile checks that a directory without a Makefile yields no

--- a/internal/adapter/makex/parse.go
+++ b/internal/adapter/makex/parse.go
@@ -1,0 +1,184 @@
+package makex
+
+import (
+	"bufio"
+	"regexp"
+	"strings"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+)
+
+// This file holds the parsing half of the Make adapter. Every function here is
+// pure: it takes captured text and returns values, reading no file and running
+// no subprocess. The impure edges — running make, reading the Makefile — live
+// in makex.go, so the parser is testable without make on the box (ADR-M002).
+
+// parseDatabase extracts targets from the output of `make -pRrq`.
+//
+// It reads the database in two passes because `.PHONY:` is printed after the
+// targets it describes: the first pass collects the target lines and the phony
+// set, the second stamps each target with its status. A Makefile declaring no
+// phony targets produces no `.PHONY:` entry at all, so the set is empty and
+// every target is correctly PhonyNo.
+//
+// The caller is responsible for pinning the locale on the make invocation —
+// the section markers this keys on are English (ADR-M002).
+func parseDatabase(out string) []domain.Target {
+	var targets []domain.Target
+	seen := make(map[string]bool)
+	phony := make(map[string]bool)
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	inFiles := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// skip the "# Files" section marker
+		if line == "# Files" {
+			inFiles = true
+			continue
+		}
+		if strings.HasPrefix(line, "# Not a target:") {
+			// next line is not a real target, skip it
+			if scanner.Scan() {
+				// consumed the fake target line
+			}
+			continue
+		}
+
+		if !inFiles {
+			continue
+		}
+
+		// The resolved .PHONY entry, read before the leading-dot skip below
+		// discards it. Multiple .PHONY declarations in the Makefile merge into
+		// this one line. Phony status is taken from here rather than from the
+		// per-target comment make prints, because a comment is localised prose
+		// while this is target-name text.
+		if declared, ok := strings.CutPrefix(line, ".PHONY:"); ok {
+			for _, name := range strings.Fields(declared) {
+				phony[name] = true
+			}
+			continue
+		}
+
+		// target lines look like "name: deps"
+		if len(line) == 0 || line[0] == '#' || line[0] == '\t' || line[0] == '.' {
+			continue
+		}
+
+		idx := strings.IndexByte(line, ':')
+		if idx <= 0 {
+			continue
+		}
+
+		name := strings.TrimSpace(line[:idx])
+
+		// filter out pattern rules, variable refs, internal targets
+		if strings.ContainsAny(name, "%$") {
+			continue
+		}
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+
+		targets = append(targets, domain.Target{
+			Name:          name,
+			Prerequisites: prerequisites(line[idx+1:]),
+		})
+	}
+
+	for i := range targets {
+		if phony[targets[i].Name] {
+			targets[i].Phony = domain.PhonyYes
+		} else {
+			targets[i].Phony = domain.PhonyNo
+		}
+	}
+
+	return targets
+}
+
+// prerequisites splits the text after a target line's colon.
+//
+// Two tokens make's syntax puts in that text are not prerequisites and are
+// dropped: "|" separates normal prerequisites from order-only ones, and ":" is
+// what remains of the second colon in a double-colon rule, which the caller's
+// split on the first colon leaves behind.
+//
+// It returns nil rather than an empty slice when there are none: strings.Fields
+// yields a non-nil empty slice for empty input, and the distinction between no
+// prerequisites and unknown prerequisites is visible to consumers.
+func prerequisites(after string) []string {
+	var prereqs []string
+	for _, field := range strings.Fields(after) {
+		if field == "|" || field == ":" {
+			continue
+		}
+		prereqs = append(prereqs, field)
+	}
+	return prereqs
+}
+
+var makeTargetRe = regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_.-]*):\s*(?:.*?##\s*(.*))?$`)
+
+// parseMakefile extracts targets from Makefile source — the fallback used when
+// make errors or the database yields nothing.
+//
+// It populates neither Phony nor Prerequisites. Phony therefore stays
+// PhonyUnknown, which is the ADR-M002 requirement, and Prerequisites stays nil:
+// the regex sees as-written, unexpanded text ($(OBJS) stays literal), which is
+// a different thing from make's resolved list. Recording one as the other is
+// the same conflation the ADR forbids for phony.
+func parseMakefile(src string) []domain.Target {
+	var targets []domain.Target
+	seen := make(map[string]bool)
+
+	scanner := bufio.NewScanner(strings.NewReader(src))
+	for scanner.Scan() {
+		matches := makeTargetRe.FindStringSubmatch(scanner.Text())
+		if matches == nil {
+			continue
+		}
+		name := matches[1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		targets = append(targets, domain.Target{
+			Name:        name,
+			Description: strings.TrimSpace(matches[2]),
+		})
+	}
+	return targets
+}
+
+var descRe = regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_.-]*):\s*.*?##\s*(.*)$`)
+
+// descriptions reads the `## comment` convention out of Makefile source,
+// keyed by target name. It is MkX's only demand on the Makefiles it reads.
+func descriptions(src string) map[string]string {
+	descs := make(map[string]string)
+
+	scanner := bufio.NewScanner(strings.NewReader(src))
+	for scanner.Scan() {
+		if matches := descRe.FindStringSubmatch(scanner.Text()); matches != nil {
+			descs[matches[1]] = strings.TrimSpace(matches[2])
+		}
+	}
+	return descs
+}
+
+// applyDescriptions overlays descriptions onto targets in place. Targets with
+// no entry keep whatever description they already carry.
+func applyDescriptions(targets []domain.Target, descs map[string]string) {
+	for i := range targets {
+		if d, ok := descs[targets[i].Name]; ok {
+			targets[i].Description = d
+		}
+	}
+}

--- a/internal/adapter/makex/parse_test.go
+++ b/internal/adapter/makex/parse_test.go
@@ -1,0 +1,429 @@
+package makex
+
+// Table tests for the pure parsing core. These are the reason the parser was
+// split from its impure edges (ADR-M002): every case here runs without make on
+// the box and without touching the filesystem, so the inputs are visible in the
+// test rather than produced by a subprocess.
+//
+// Known limit, stated rather than engineered around: a hand-trimmed database
+// sample can drift from what make really emits. TestCharacterization in
+// internal/app covers that — it runs real make over the fixtures end to end.
+// These tests cover the parsing logic; that oracle covers the input assumption.
+
+import (
+	"testing"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+)
+
+// sampleSource is the Makefile both samples below describe. It carries phony
+// and non-phony targets, targets with and without prerequisites, targets with
+// and without a `## comment`, and a pattern rule.
+const sampleSource = `.PHONY: all clean
+
+all: build test ## Build and test everything
+	@echo all
+
+build: main.o ## Compile
+	@echo build
+
+test: build
+	@echo test
+
+main.o: main.c
+	@echo obj
+
+clean:
+	@echo clean
+
+%.o: %.c
+	@echo pattern
+`
+
+// sampleDatabase is real `make -pRrq` output for sampleSource (GNU Make 4.3),
+// trimmed to the sections the parser reads and with the per-target status
+// comments shortened. Three properties of the real output are load-bearing and
+// preserved verbatim:
+//
+//   - "# Implicit Rules" precedes "# Files", so the pattern rule sits in the
+//     preamble the parser skips.
+//   - make prints targets in hash order, not source order.
+//   - ".PHONY:" is printed after the targets it describes, which is why
+//     parseDatabase reads the database in two passes.
+const sampleDatabase = `# GNU Make 4.3
+# Make data base, printed on Sat Aug  1 10:20:46 2026
+
+# Implicit Rules
+
+%.o: %.c
+#  recipe to execute (from 'Makefile', line 19):
+	@echo pattern
+
+# 1 implicit rules, 0 (0.0%) terminal.
+# Files
+
+# Not a target:
+Makefile:
+#  Implicit rule search has been done.
+#  File has been updated.
+
+clean:
+#  Phony target (prerequisite of .PHONY).
+#  File does not exist.
+#  recipe to execute (from 'Makefile', line 16):
+	@echo clean
+
+# Not a target:
+.DEFAULT:
+#  Implicit rule search has not been done.
+
+all: build test
+#  Phony target (prerequisite of .PHONY).
+#  File does not exist.
+#  recipe to execute (from 'Makefile', line 4):
+	@echo all
+
+build: main.o
+#  Implicit rule search has not been done.
+#  File does not exist.
+#  recipe to execute (from 'Makefile', line 7):
+	@echo build
+
+# Not a target:
+main.c:
+#  Implicit rule search has been done.
+#  File does not exist.
+
+test: build
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  recipe to execute (from 'Makefile', line 10):
+	@echo test
+
+main.o: main.c
+#  Implicit rule search has not been done.
+#  File does not exist.
+#  recipe to execute (from 'Makefile', line 13):
+	@echo obj
+
+.PHONY: all clean
+#  Implicit rule search has not been done.
+
+# files hash-table stats:
+# Load=9/1024=1%, Rehash=0, Collisions=0/27=0%
+`
+
+// databaseWant is what sampleDatabase parses to, before descriptions are
+// applied. Order is make's, not alphabetical — Discover sorts afterwards.
+func databaseWant() []domain.Target {
+	return []domain.Target{
+		{Name: "clean", Phony: domain.PhonyYes},
+		{Name: "all", Phony: domain.PhonyYes, Prerequisites: []string{"build", "test"}},
+		{Name: "build", Phony: domain.PhonyNo, Prerequisites: []string{"main.o"}},
+		{Name: "test", Phony: domain.PhonyNo, Prerequisites: []string{"build"}},
+		{Name: "main.o", Phony: domain.PhonyNo, Prerequisites: []string{"main.c"}},
+	}
+}
+
+// TestParseDatabase covers the primary `make -pRrq` path: which lines count as
+// targets, the phony set read from the resolved `.PHONY:` entry, and make's
+// resolved prerequisite lists.
+func TestParseDatabase(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want []domain.Target
+	}{
+		{
+			// clean is phony with no prerequisites, all is phony with two,
+			// build/test/main.o are not phony and each has one. The pattern
+			// rule and the "# Not a target:" entries are absent from the result.
+			name: "phony and non-phony, with and without prerequisites",
+			out:  sampleDatabase,
+			want: databaseWant(),
+		},
+		{
+			// No .PHONY entry at all: the phony set is empty, so every target
+			// reads PhonyNo. That is the honest answer rather than a degraded
+			// one — make omits the entry precisely because nothing is phony.
+			name: "no .PHONY entry means every target is PhonyNo",
+			out:  "# Files\n\nbuild: main.o\n\t@echo build\n",
+			want: []domain.Target{
+				{Name: "build", Phony: domain.PhonyNo, Prerequisites: []string{"main.o"}},
+			},
+		},
+		{
+			// Two .PHONY declarations in a Makefile merge into one resolved
+			// line, so the parser never has to accumulate across entries — but
+			// it must still read every name on the line it does get.
+			name: "every name on the .PHONY line is read",
+			out:  "# Files\n\nall:\n\nbuild:\n\nclean:\n\n.PHONY: all clean\n",
+			want: []domain.Target{
+				{Name: "all", Phony: domain.PhonyYes},
+				{Name: "build", Phony: domain.PhonyNo},
+				{Name: "clean", Phony: domain.PhonyYes},
+			},
+		},
+		{
+			// The same target printed twice keeps its first appearance.
+			name: "duplicate target lines are collapsed",
+			out:  "# Files\n\nbuild: first\n\nbuild: second\n",
+			want: []domain.Target{
+				{Name: "build", Phony: domain.PhonyNo, Prerequisites: []string{"first"}},
+			},
+		},
+		{
+			// "|" is make's separator for order-only prerequisites, not a
+			// prerequisite itself. Verified against GNU Make 4.3, which prints
+			// the line as written: "all: build | dir".
+			name: "the order-only separator is not a prerequisite",
+			out:  "# Files\n\nall: build | dir\n",
+			want: []domain.Target{
+				{Name: "all", Phony: domain.PhonyNo, Prerequisites: []string{"build", "dir"}},
+			},
+		},
+		{
+			// A double-colon rule splits on its first colon, leaving the second
+			// in the prerequisite text. It is syntax, not a prerequisite.
+			name: "the residue of a double-colon rule is not a prerequisite",
+			out:  "# Files\n\nboth:: one\n",
+			want: []domain.Target{
+				{Name: "both", Phony: domain.PhonyNo, Prerequisites: []string{"one"}},
+			},
+		},
+		{
+			// A target whose only prerequisites are order-only still reports
+			// nil rather than an empty slice.
+			name: "dropping every token leaves nil, not an empty slice",
+			out:  "# Files\n\nall: |\n",
+			want: []domain.Target{
+				{Name: "all", Phony: domain.PhonyNo},
+			},
+		},
+		{
+			// Everything above the "# Files" marker is preamble: variables,
+			// implicit rules, and the directory stack all contain colons.
+			name: "target-shaped lines above # Files are ignored",
+			out:  "CFLAGS := -O2\n\n# Implicit Rules\n\n%.o: %.c\n\ndecoy: not-a-target\n",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertTargets(t, parseDatabase(tt.out), tt.want)
+		})
+	}
+}
+
+// TestParseMakefile covers the regex fallback. Its defining property is what it
+// does *not* report: phony status stays PhonyUnknown and Prerequisites stays
+// nil, so a fallback-discovered target is never mistaken for one make resolved.
+func TestParseMakefile(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []domain.Target
+	}{
+		{
+			// Recorded as-built, and narrower than the database path in two
+			// ways worth seeing side by side with databaseWant(): the fallback
+			// reports PhonyUnknown and nil prerequisites for everything, and it
+			// does not see `test` or `main.o` at all — its regex matches a
+			// target carrying prerequisites only when a `##` comment follows.
+			name: "fallback reports PhonyUnknown and nil prerequisites",
+			src:  sampleSource,
+			want: []domain.Target{
+				{Name: "all", Description: "Build and test everything", Phony: domain.PhonyUnknown},
+				{Name: "build", Description: "Compile", Phony: domain.PhonyUnknown},
+				{Name: "clean", Description: "", Phony: domain.PhonyUnknown},
+			},
+		},
+		{
+			name: "the .PHONY declaration is not itself a target",
+			src:  ".PHONY: all clean\n\nall: ## Everything\n",
+			want: []domain.Target{
+				{Name: "all", Description: "Everything", Phony: domain.PhonyUnknown},
+			},
+		},
+		{
+			name: "duplicate target lines are collapsed",
+			src:  "build: ## First\nbuild: ## Second\n",
+			want: []domain.Target{
+				{Name: "build", Description: "First", Phony: domain.PhonyUnknown},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertTargets(t, parseMakefile(tt.src), tt.want)
+		})
+	}
+}
+
+// TestDescriptions covers the `## comment` convention on its own, and applied
+// over database results — the composition Discover performs when the primary
+// path succeeds.
+func TestDescriptions(t *testing.T) {
+	t.Run("read from source", func(t *testing.T) {
+		tests := []struct {
+			name string
+			src  string
+			want map[string]string
+		}{
+			{
+				name: "only the targets that carry a ## comment",
+				src:  sampleSource,
+				want: map[string]string{
+					"all":   "Build and test everything",
+					"build": "Compile",
+				},
+			},
+			{
+				name: "a single # is not the convention",
+				src:  "build: # Compile\n",
+				want: map[string]string{},
+			},
+			{
+				name: "surrounding whitespace is trimmed",
+				src:  "build:   ##    Compile   \n",
+				want: map[string]string{"build": "Compile"},
+			},
+			{
+				name: "no Makefile source at all",
+				src:  "",
+				want: map[string]string{},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got := descriptions(tt.src)
+				if len(got) != len(tt.want) {
+					t.Fatalf("got %d descriptions, want %d: %v", len(got), len(tt.want), got)
+				}
+				for name, want := range tt.want {
+					if got[name] != want {
+						t.Errorf("%s: got %q, want %q", name, got[name], want)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("applied over database results", func(t *testing.T) {
+		targets := parseDatabase(sampleDatabase)
+		applyDescriptions(targets, descriptions(sampleSource))
+
+		want := databaseWant()
+		want[1].Description = "Build and test everything" // all
+		want[2].Description = "Compile"                   // build
+
+		assertTargets(t, targets, want)
+	})
+
+	t.Run("a target with no entry keeps the description it has", func(t *testing.T) {
+		targets := []domain.Target{{Name: "build", Description: "from the fallback"}}
+		applyDescriptions(targets, map[string]string{"other": "unrelated"})
+
+		assertTargets(t, targets, []domain.Target{
+			{Name: "build", Description: "from the fallback"},
+		})
+	})
+}
+
+// TestZeroTargets covers a Makefile that produces no targets on either path:
+// an empty result rather than a panic, which is what lets Discover fall through
+// from the primary path to the fallback and then report nothing.
+func TestZeroTargets(t *testing.T) {
+	// A Makefile holding only a variable and a comment declares no rules, so
+	// make's "# Files" section contains nothing but its own bookkeeping.
+	const emptyDatabase = `# Files
+
+# Not a target:
+Makefile:
+#  Implicit rule search has been done.
+
+# files hash-table stats:
+`
+	const emptySource = "# a comment\nCFLAGS := -O2\n"
+
+	tests := []struct {
+		name string
+		got  []domain.Target
+	}{
+		{name: "database path, empty # Files section", got: parseDatabase(emptyDatabase)},
+		{name: "database path, make produced no output at all", got: parseDatabase("")},
+		{name: "fallback path, no rules in the source", got: parseMakefile(emptySource)},
+		{name: "fallback path, no Makefile to read", got: parseMakefile("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.got) != 0 {
+				t.Errorf("got %d targets, want 0: %+v", len(tt.got), tt.got)
+			}
+		})
+	}
+}
+
+// TestPhonyStatusString pins the strings the characterization golden records,
+// so a rename shows up here rather than only as golden churn.
+func TestPhonyStatusString(t *testing.T) {
+	tests := []struct {
+		status domain.PhonyStatus
+		want   string
+	}{
+		{domain.PhonyUnknown, "unknown"},
+		{domain.PhonyNo, "no"},
+		{domain.PhonyYes, "yes"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.status.String(); got != tt.want {
+			t.Errorf("PhonyStatus(%d).String() = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+// assertTargets compares parsed targets against the expectation in order, field
+// by field. domain.Target holds a slice and so is not comparable with ==; the
+// helper is hand-rolled to avoid taking a module dependency for it.
+//
+// nil and empty prerequisite lists are treated as distinct: the parser
+// normalises "no prerequisites" to nil deliberately, and a helper that blurred
+// the two would stop checking that.
+func assertTargets(t *testing.T, got, want []domain.Target) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d targets, want %d:\n got: %+v\nwant: %+v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		g, w := got[i], want[i]
+		if g.Name != w.Name {
+			t.Errorf("target %d name: got %q, want %q", i, g.Name, w.Name)
+		}
+		if g.Description != w.Description {
+			t.Errorf("target %d (%s) description: got %q, want %q", i, w.Name, g.Description, w.Description)
+		}
+		if g.Phony != w.Phony {
+			t.Errorf("target %d (%s) phony: got %s, want %s", i, w.Name, g.Phony, w.Phony)
+		}
+		if (g.Prerequisites == nil) != (w.Prerequisites == nil) {
+			t.Errorf("target %d (%s) prerequisites: got %#v, want %#v", i, w.Name, g.Prerequisites, w.Prerequisites)
+			continue
+		}
+		if len(g.Prerequisites) != len(w.Prerequisites) {
+			t.Errorf("target %d (%s) prerequisites: got %q, want %q", i, w.Name, g.Prerequisites, w.Prerequisites)
+			continue
+		}
+		for j := range w.Prerequisites {
+			if g.Prerequisites[j] != w.Prerequisites[j] {
+				t.Errorf("target %d (%s) prerequisites: got %q, want %q", i, w.Name, g.Prerequisites, w.Prerequisites)
+				break
+			}
+		}
+	}
+}

--- a/internal/app/characterization_test.go
+++ b/internal/app/characterization_test.go
@@ -186,14 +186,30 @@ func countPrefix(s, prefix string) int {
 }
 
 // serializeProjects renders discovery results as deterministic, path-free text.
+//
+// Every field a Target retains appears on the target's own line. Keeping it to
+// one line is a constraint rather than a preference: lineDelta below is a
+// multiset over lines, so splitting phony onto a sub-line would emit one
+// identical `+ phony: no` entry per target and destroy the readability of the
+// rebaseline receipt — the thing the receipt exists for.
 func serializeProjects(projects []domain.Project) string {
 	var b strings.Builder
 	for _, p := range projects {
 		fmt.Fprintf(&b, "project %s\n", filepath.ToSlash(p.Name))
 		fmt.Fprintf(&b, "  description: %s\n", p.Description)
 		for _, t := range p.Targets {
-			fmt.Fprintf(&b, "  target %s: %s\n", t.Name, t.Description)
+			fmt.Fprintf(&b, "  target %s (phony=%s, prereqs=%s): %s\n",
+				t.Name, t.Phony, serializePrerequisites(t.Prerequisites), t.Description)
 		}
 	}
 	return b.String()
+}
+
+// serializePrerequisites renders a prerequisite list for the golden, using "-"
+// for none so the field is never empty and the line stays readable.
+func serializePrerequisites(prereqs []string) string {
+	if len(prereqs) == 0 {
+		return "-"
+	}
+	return strings.Join(prereqs, ",")
 }

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -15,11 +15,55 @@ type Project struct {
 	Targets     []Target
 }
 
+// PhonyStatus is whether a Target is a phony target — declared as a
+// prerequisite of `.PHONY:` rather than naming a file it builds.
+//
+// Per ADR-M002 the zero value is PhonyUnknown, not PhonyNo: a discovery path
+// that cannot determine phony status reports the honest answer by construction
+// rather than by remembering to set the field.
+type PhonyStatus int
+
+const (
+	// PhonyUnknown means the discovery path could not determine phony status.
+	PhonyUnknown PhonyStatus = iota
+	// PhonyNo means the target is not declared phony.
+	PhonyNo
+	// PhonyYes means the target is declared phony.
+	PhonyYes
+)
+
+// String renders the status for display and for the characterization golden.
+func (p PhonyStatus) String() string {
+	switch p {
+	case PhonyNo:
+		return "no"
+	case PhonyYes:
+		return "yes"
+	default:
+		return "unknown"
+	}
+}
+
 // Target is one Make target in a Project's Makefile. Description comes from the
 // `## comment` convention, and is empty when the target carries none.
 type Target struct {
 	Name        string
 	Description string
+
+	// Phony is PhonyUnknown on any discovery path that cannot determine it.
+	// Per ADR-M002, consumers must not treat PhonyUnknown and PhonyNo as
+	// equivalent.
+	Phony PhonyStatus
+
+	// Prerequisites is make's resolved prerequisite list, and is meaningful
+	// only when Phony != PhonyUnknown.
+	//
+	// nil carries two distinct meanings that share one representation: on the
+	// database path it means the target has no prerequisites; on the regex
+	// fallback path, which does not populate this field at all, it means
+	// unknown. Phony is what distinguishes them — PhonyUnknown implies the
+	// fallback path and therefore that Prerequisites is unknown too.
+	Prerequisites []string
 }
 
 // Command describes a subprocess to run with full terminal handover.

--- a/testdata/fixtures.golden
+++ b/testdata/fixtures.golden
@@ -1,13 +1,13 @@
 project alpha
   description: Alpha is a fixture project with four targets, one of them undescribed.
-  target build: Compile the binary
-  target clean: Remove build output
-  target install: 
-  target test: Run the test suite
+  target build (phony=no, prereqs=-): Compile the binary
+  target clean (phony=no, prereqs=-): Remove build output
+  target install (phony=no, prereqs=-): 
+  target test (phony=no, prereqs=-): Run the test suite
 project beta
   description: Beta is a fixture project whose Makefile declares a .PHONY special target.
-  target fmt: Format the source
-  target lint: Run the linter
+  target fmt (phony=yes, prereqs=-): Format the source
+  target lint (phony=yes, prereqs=-): Run the linter
 project beta/nested
   description: Beta Nested is a fixture project one level below another project.
-  target docs: Generate the documentation
+  target docs (phony=no, prereqs=-): Generate the documentation


### PR DESCRIPTION
Closes TAE-47.

The architect plan this implements is the approved comment on
[TAE-47](https://linear.app/taelron/issue/TAE-47/make-parser-retain-phony-and-prerequisites-with-table-tests).

## This is a behaviour change, not a refactor

Most of the diff is a parse/exec split that reads like a refactor. One part is not.

The `make -pRrq` parser gates on the English string `# Files`. GNU Make localises the
database's section headers, so on a machine with a non-C locale the primary path returned
zero targets and discovery fell silently through to the regex fallback. That is pre-existing
on `main`, and invisible only because the fallback covers it.

`LC_ALL=C LANG=C` is now pinned on the invocation, recorded in ADR-M002. **On a localised
machine this moves discovery from the fallback to the primary path, and the two paths do not
return the same target list** — the fallback's regex, for instance, does not discover a
target that carries prerequisites without a `##` comment. Users on such a machine may see a
different set of targets after this change.

The pin is a no-op on the dev box (`en_US.UTF-8`) and contributes nothing to the golden diff
below. It is not a no-op everywhere.

The pin is in scope for this issue rather than split out because without it the feature does
not work: every target on a localised machine would report phony as *unknown*, making the
first two acceptance criteria unsatisfiable there.

## What was built

| Acceptance criterion | Where |
| -- | -- |
| Target carries `Phony` and `Prerequisites` beside `Name` and `Description` | `internal/domain/domain.go` |
| Regex-discovered targets report `Phony` as **unknown**, not false | `PhonyUnknown` is the zero value; `parseMakefile` sets neither field |
| Parsing is a pure function over captured make output | `internal/adapter/makex/parse.go` — no I/O, no subprocess |
| Table tests: database path, fallback path, `## comment`, zero targets | `internal/adapter/makex/parse_test.go` |
| No grouping convention introduced | Nothing added; ADR-M002 keeps it out of scope |

Three design points worth stating:

- **`PhonyStatus` is a three-valued enum, not a `*bool`.** `PhonyUnknown` is the zero value,
  so a discovery path that cannot determine phony status reports the honest answer by
  construction rather than by remembering to set a field.
- **Phony comes from the resolved `.PHONY:` line, not the per-target comment.** Make's
  comment prose is localised (`# Phony target (prerequisite of .PHONY).` →
  `# Cible factice…`); a `.PHONY:` entry is target-name text and so is immune. It is printed
  *after* the targets it names, hence the second pass.
- **The fallback leaves `Prerequisites` nil deliberately.** The regex sees as-written,
  unexpanded text (`$(OBJS)` stays literal), which is not make's resolved list. Recording one
  as the other is the conflation ADR-M002 forbids for phony. `PhonyUnknown` is what signals
  that nil means *unknown* there rather than *none*.

Neither field has a consumer at merge time. ADR-M002 accepts that explicitly as the cost of
not opening the parser a third time. `internal/ui/tui` is untouched.

## One deviation from the plan

The plan defines `Prerequisites` as "make's resolved prerequisite list". The first
implementation admitted two tokens that are make *syntax* rather than prerequisites, both
confirmed against GNU Make 4.3:

```
all: build | dir      →  ["build", "|", "dir"]     "|" separates order-only prerequisites
both:: one            →  [":", "one"]              ":" is the double-colon residue
```

`prerequisites()` now drops both. Caught by the in-session review, fixed under the plan's own
definition of the field. It touches no fixture, adds no consumer, and does not move the
golden — confirmed by a second `make rebaseline-golden` run reporting
`(no change — behaviour matches the existing golden)`.

## Golden receipt — `make rebaseline-golden`

The one M1 issue where the golden legitimately moves, which is exactly what makes an
*unintended* golden change invisible: it would hide inside the legitimate one. The TAE-52
liveness guard does not help — it detects the oracle being removed, not the oracle being
re-anchored to wrong behaviour. So the receipt is here verbatim.

```
$ make rebaseline-golden
go test -count=1 -v -run '^TestCharacterization$' ./internal/app/ -rebaseline
=== RUN   TestCharacterization

REBASELINE testdata/fixtures.golden
  -   target build: Compile the binary
  -   target clean: Remove build output
  -   target docs: Generate the documentation
  -   target fmt: Format the source
  -   target install: 
  -   target lint: Run the linter
  -   target test: Run the test suite
  +   target build (phony=no, prereqs=-): Compile the binary
  +   target clean (phony=no, prereqs=-): Remove build output
  +   target docs (phony=no, prereqs=-): Generate the documentation
  +   target fmt (phony=yes, prereqs=-): Format the source
  +   target install (phony=no, prereqs=-): 
  +   target lint (phony=yes, prereqs=-): Run the linter
  +   target test (phony=no, prereqs=-): Run the test suite
7 added, 7 removed
This re-anchors the behaviour oracle. Commit only if the change is intended and reviewed.

--- PASS: TestCharacterization (0.00s)
PASS
ok  	github.com/Gaetan-Jaminon/mkx/internal/app	0.007s
```

**The plan predicted 8 added / 8 removed. The receipt is 7 / 7, and 7 is correct.** The
fixtures hold seven targets — alpha 4 (`build`, `clean`, `install`, `test`) + beta 2 (`fmt`,
`lint`) + beta/nested 1 (`docs`); `deep/level2/level3` is beyond the depth limit and
`node_modules` is excluded. The plan's own line-by-line enumeration ("alpha ×4, beta/nested
×1 → phony=no; beta fmt, beta lint → phony=yes") also sums to 7, so the `8` was an
arithmetic slip in the plan text. Nothing was lost in the rebaseline — the golden on `main`
already had seven target lines:

```
$ git show HEAD:testdata/fixtures.golden | grep -c '^  target '
7
```

Before rebaselining, `make verify` went red as required. A green result there would have
meant the serializer change never took effect and the receipt above would show no movement.

## Golden diff — for line-by-line reading

```diff
 project alpha
   description: Alpha is a fixture project with four targets, one of them undescribed.
-  target build: Compile the binary
-  target clean: Remove build output
-  target install: 
-  target test: Run the test suite
+  target build (phony=no, prereqs=-): Compile the binary
+  target clean (phony=no, prereqs=-): Remove build output
+  target install (phony=no, prereqs=-): 
+  target test (phony=no, prereqs=-): Run the test suite
 project beta
   description: Beta is a fixture project whose Makefile declares a .PHONY special target.
-  target fmt: Format the source
-  target lint: Run the linter
+  target fmt (phony=yes, prereqs=-): Format the source
+  target lint (phony=yes, prereqs=-): Run the linter
 project beta/nested
   description: Beta Nested is a fixture project one level below another project.
-  target docs: Generate the documentation
+  target docs (phony=no, prereqs=-): Generate the documentation
```

Each moved line, checked against its fixture Makefile:

| Line | Expected | Fixture evidence |
| -- | -- | -- |
| `alpha/build`, `clean`, `install`, `test` | `phony=no` | `alpha/Makefile` declares no `.PHONY` |
| `beta/fmt`, `beta/lint` | `phony=yes` | `beta/Makefile` line 1: `.PHONY: lint fmt` |
| `beta/nested/docs` | `phony=no` | `beta/nested/Makefile` declares no `.PHONY` |
| all seven | `prereqs=-` | no fixture target declares a prerequisite |

No `project` or `description` line moved. Every target kept its name and description and
gained exactly one annotation.

**Known coverage gap, stated rather than hidden.** Because no fixture declares a
prerequisite, `prereqs=-` on all seven lines means the real-make oracle never round-trips a
*non-empty* prerequisite list. Prerequisite parsing is covered by the table tests
(`TestParseDatabase`), which are hand-trimmed samples — so the assumption that those samples
match what make really emits is not itself checked for the prerequisite field. This is the
plan's deliberate trade: adding a prerequisite to a fixture would have made the golden diff
non-uniform and harder to read at merge time, which is the diff above. Raised by the
in-session review; recorded here rather than acted on, since fixture changes are out of scope
for TAE-47.

## Verification handoff

Run top to bottom from the repo root. Steps 3–6 are the merge gate.

| # | Command | Purpose | Expected |
| -- | -- | -- | -- |
| 1 | `make build` | It compiles | Binary produced, no other output |
| 2 | `make tidy-check` | No new module dependency crept in | Clean; `go.mod`/`go.sum` unchanged |
| 3 | `make verify-parser` | The new pure table tests | All cases PASS, listed by name |
| 4 | `make verify` | Discovery matches the committed golden | PASS |
| 5 | `git diff origin/main -- testdata/fixtures.golden` | Read the moved oracle against the table above | The diff shown in this description, nothing more |
| 6 | `make verify-guards` | The oracle guards still fail for the right reasons | Every case PASS with its own marker |
| 7 | `make test` | Full suite | All packages PASS |
| 8 | `make run` | The TUI still lists targets | Projects and targets render as before — no UI change was made |

Step 5 is raw `git` because wrapping a diff in a Make target would obscure it.

To reproduce the red-before-rebaseline gate rather than take it on trust:
`git stash` is not enough — check out the parent of the golden commit's serializer change and
run `make verify` against the new golden, or simply revert `serializeProjects` locally and
confirm `make verify` goes red.

All eight steps were run in-session against this branch, and again from a clean `git clone`
of it to confirm nothing depends on untracked local state.
