### PR TITLE
M2 kickoff: verify-guards in CI, and CLAUDE.md points at M2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,22 @@ jobs:
           go-version-file: go.mod
       - run: make build
       - run: make test
+
+  # The golden-oracle guards get their own job rather than a step in the matrix
+  # above, for two reasons. It runs on ubuntu only: the sabotage script uses GNU
+  # sed (`sed -i` with no argument, and `\n` in a replacement), which the BSD sed
+  # on macOS runners rejects — the job would fail there for a reason that has
+  # nothing to do with the guards. And as a separate job it runs concurrently
+  # with the matrix, so the slowest check in CI does not extend the critical path.
+  #
+  # Nothing in `go test ./...` touches the guard script, so unlike `make verify`
+  # this proof is not transitive. If it does not run here, it runs only when
+  # someone remembers.
+  guards:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make verify-guards

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Linear is canonical. Everything below points at Linear rather than restating it;
 
 **Phase 1 — minimum viable implementation.** Per @AI Workflow, Phase 1 ends with v1.0: an installable, usable artifact delivering the core value the spec promises. The phase is gated on that deliverable, not on a schedule.
 
-**Active milestone: M1 — Structure** (in progress) — [MkX project in Linear](https://linear.app/taelron/project/mkx-7067f8030ab4).
+**Active milestone: M2 — Target filtering and branch switching** (in progress) — [MkX project in Linear](https://linear.app/taelron/project/mkx-7067f8030ab4).
 
 This file is updated when the active milestone changes, typically once per milestone closure.
 


### PR DESCRIPTION
Closes TAE-55.

Trivial-issue waiver — built directly, no plan session. Two mechanical items from M1's
exit verification, neither a criterion failure.

## Acceptance criteria

| Criterion | Where |
| -- | -- |
| CI runs `make verify-guards`; a broken guard fails the workflow | `.github/workflows/ci.yml` — new `guards` job |
| `CLAUDE.md` names M2 as the active milestone and links it | `CLAUDE.md` line 11 |
| No other `CLAUDE.md` content changes | `git diff --numstat CLAUDE.md` → `1  1  CLAUDE.md` |

## The decision: every PR, not main-only

**`verify-guards` runs on every pull request and every push to `main`.**

The cost argument for main-only does not survive the numbers. The script takes **3.09s**
locally (`/usr/bin/time` on the full run), and it is a **separate job**, so it runs
concurrently with the existing build matrix rather than extending it. It is still the
slowest single check, but it is no longer on the critical path.

Against that: deferring to post-merge means discovering a broken guard *after* it is on
`main`. These guards are the only thing standing between a rebaselined oracle and an
unnoticed behaviour change — precisely the class of problem the merge gate exists for.
Paying three concurrent seconds per PR to keep that check on the correct side of the gate
is the trade.

**Ubuntu only, and deliberately not a step in the existing matrix.** The sabotage script
uses GNU sed — `sed -i` with no argument, and `\n` in a replacement — both of which the BSD
sed on `macos-latest` rejects. Adding it to the matrix would produce a red macOS job that
says nothing about the guards. Making the script portable is a larger change than this
issue carries, so it is noted rather than done.

## Verification handoff

Run top to bottom from the repo root.

| # | Command | Purpose | Expected |
| -- | -- | -- | -- |
| 1 | `make build` | It compiles | Binary produced, no other output |
| 2 | `make test` | Full suite, unaffected by this change | All packages PASS |
| 3 | `make verify` | Discovery still matches the golden | PASS |
| 4 | `make verify-guards` | The check CI now runs | 8 cases PASS, "All guards tripped as required" |
| 5 | `git diff --numstat CLAUDE.md main` | Nothing else in the doc moved | `1  1  CLAUDE.md` |

Step 5 is raw `git` because the assertion is about the size of the diff, which a Make
target would obscure.

### Output

**1–3:**

```
$ make build
go build -o mkx ./cmd/mkx
exit=0

$ make test
go test ./...
?   	github.com/Gaetan-Jaminon/mkx/cmd/mkx	[no test files]
ok  	github.com/Gaetan-Jaminon/mkx/internal/adapter/makex	(cached)
?   	github.com/Gaetan-Jaminon/mkx/internal/adapter/workspace	[no test files]
ok  	github.com/Gaetan-Jaminon/mkx/internal/app	(cached)
?   	github.com/Gaetan-Jaminon/mkx/internal/domain	[no test files]
?   	github.com/Gaetan-Jaminon/mkx/internal/ui/tui	[no test files]
?   	github.com/Gaetan-Jaminon/mkx/internal/ui/tui/styles	[no test files]
exit=0

$ make verify
=== RUN   TestCharacterization
--- PASS: TestCharacterization (0.00s)
=== RUN   TestCharacterizationIsRegistered
--- PASS: TestCharacterizationIsRegistered (0.00s)
PASS
ok  	github.com/Gaetan-Jaminon/mkx/internal/app	0.007s
exit=0
```

**4:**

```
$ make verify-guards
PASS  missing golden, run 1
PASS  missing golden, no rewrite
PASS  missing golden, run 2 (the old silent pass)
PASS  empty golden
PASS  oracle renamed
PASS  oracle skipped
PASS  oracle excluded by //go:build
PASS  oracle file deleted
All guards tripped as required.
exit=0
```

### Proving the new CI step can fail

A green run of a checking mechanism is the weakest evidence it works — it shows only that
nothing tripped. Since the acceptance criterion is "a broken guard fails the workflow", the
check is whether `make verify-guards` goes **red**, and with the right message, when a guard
is genuinely broken.

Constructed: in a throwaway copy of the tree, the empty-golden guard was removed from
`assertGoldenWellFormed` (`_ = golden // SABOTAGE`), so that case can no longer trip.

```
$ make verify-guards          # in the sabotaged copy
PASS  missing golden, run 1
PASS  missing golden, no rewrite
PASS  missing golden, run 2 (the old silent pass)
FAIL  empty golden
PASS  oracle renamed
PASS  oracle skipped
PASS  oracle excluded by //go:build
PASS  oracle file deleted
1 guard(s) failed to trip — the oracle is not protected.
exit=2
```

Non-zero exit, naming the specific guard. The working tree was never touched; the copy is
deleted.

### Workflow YAML, as parsed

```
job: build   runs-on: ${{ matrix.os }}      job: guards  runs-on: ubuntu-latest
    actions/checkout@v4                         actions/checkout@v4
    actions/setup-go@v5                         actions/setup-go@v5
    make build                                  make verify-guards
    make test
```

Triggers unchanged: `push: [main]`, `pull_request: [main]`.

## Unrelated finding: the GitHub↔Linear integration is not connected

TAE-47 used the Linear-generated branch name and its issue still had to be closed by hand,
so this PR was asked to check whether the branch name was the cause. It is not.

```
$ linear: { integrations(first:20){ nodes{ service } } }
{"data":{"integrations":{"nodes":[]}}}
```

No integrations are connected to the workspace at all. Corroborating:

- All six merged M1 issues (TAE-46, 47, 48, 49, 51, 52) have **zero attachments**. A
  connected integration attaches the PR to the issue it references.
- TAE-47's history shows the `Todo → Done` transition was made by `gaetan.jaminon@taelron.com`,
  not by an integration actor.

So no branch name will ever close an issue on merge here, and `Closes TAE-55` above will not
either — expect to close it by hand. Connecting the integration is its own issue; flagged
rather than done, since it is outside TAE-55's scope and is a workspace-level change rather
than a repo one.
