### PR TITLE
Modal overlay frame and help overlay; move README off ?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY   := mkx
 FIXTURES := testdata/fixtures
 
-.PHONY: build test verify verify-parser verify-guards rebaseline-golden tidy-check run
+.PHONY: build test verify verify-parser verify-tui verify-guards rebaseline-golden tidy-check run
 
 build: ## Compile the mkx binary
 	go build -o $(BINARY) ./cmd/mkx
@@ -14,6 +14,9 @@ verify: ## Check discovery behaviour against the committed golden
 
 verify-parser: ## Run the pure parser table tests
 	go test -v -count=1 ./internal/adapter/makex/
+
+verify-tui: ## Run the TUI keymap, modal and overlay tests by name
+	go test -v -count=1 ./internal/ui/tui/
 
 verify-guards: ## Prove the golden guards fail — sabotages a throwaway copy, never this tree
 	./scripts/verify-oracle-guards.sh

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Discover projects in a workspace, browse their Make targets, and run them with f
 - Target descriptions from `## comment` convention
 - Full terminal handover — interactive prompts work natively
 - Git pull and refresh targets with `g` key
-- README viewer with rendered markdown via `?` key
+- README viewer with rendered markdown via `R` key
+- Context-sensitive help overlay via `?` key
 - Status bar with exit code and duration
 
 ## Install
@@ -50,11 +51,18 @@ mkx
 |-----|-------------|-------------|
 | j/k, arrows | Navigate | Navigate |
 | Enter | Drill into project | Run target |
-| r | - | Run target |
 | g | Git pull & refresh | Git pull & refresh |
-| ? | View README | View README |
+| R | View README | View README |
+| ? | Help overlay | Help overlay |
 | Esc | - | Back |
 | q | Quit | Quit |
+
+`?` opens a help overlay listing the keys available in the current view. The
+README viewer moved to `R` to free it.
+
+`r` is not bound. Across Taelron TUIs `r` means *refresh*, and mkx's target
+lists are parsed once at startup, so there is nothing to refresh. It used to
+run the selected target — press `Enter` instead.
 
 ## Development
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/ansi v0.10.2
 	github.com/mattn/go-runewidth v0.0.17
 )
 
@@ -14,7 +15,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/ansi v0.10.2 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect

--- a/internal/ui/tui/keymap.go
+++ b/internal/ui/tui/keymap.go
@@ -1,0 +1,104 @@
+package tui
+
+import (
+	"slices"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/ui/tui/styles"
+)
+
+// binding is one key-triggered action, declared once and projected three ways:
+// into the hint bar, into the help overlay, and into key dispatch.
+//
+// Carrying the handler here is what closes the drift the issue names. A key
+// documented in help but no longer handled, or handled but undocumented, is
+// not expressible — there is one declaration, not three lists to keep in step.
+type binding struct {
+	// keys are every key string that triggers this action, as tea.KeyMsg
+	// reports them: {"up", "k"}.
+	keys []string
+	// display is how the key reads to the user: "↑↓".
+	display string
+	// label is the hint bar text: "Navigate".
+	label string
+	// help is the fuller sentence the help overlay shows: "Move the cursor up".
+	help string
+	// inBar marks a binding that appears in the hint bar. Help-only bindings
+	// (q/Quit in the target view) clear it.
+	inBar bool
+	// handler runs the action. It receives the key that triggered it, so one
+	// handler can serve several keys.
+	handler func(Model, string) (Model, tea.Cmd)
+}
+
+// keymap is a view's complete set of bindings — the single source for its hint
+// bar, its help overlay and its key dispatch.
+type keymap []binding
+
+// hintBar renders the inBar bindings as styled "display/label" pairs separated
+// by two spaces, per the @UI Patterns hint bar format.
+//
+// Entries are deduped on display+label: ↑/k and ↓/j are four keys and two
+// handlers, but one visible ↑↓/Navigate.
+func (k keymap) hintBar() string {
+	var parts []string
+	seen := make(map[string]bool)
+
+	for _, b := range k {
+		if !b.inBar {
+			continue
+		}
+		key := b.display + "/" + b.label
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		parts = append(parts, styles.HintKey.Render(b.display)+styles.HintAction.Render("/"+b.label))
+	}
+
+	return strings.Join(parts, "  ")
+}
+
+// helpRows renders every binding — not just the ones in the hint bar — as
+// "display — help" rows with the key column aligned, per the @UI Patterns help
+// overlay format. Deduped the same way as hintBar.
+func (k keymap) helpRows() []string {
+	type row struct{ display, help string }
+
+	var rows []row
+	seen := make(map[string]bool)
+	width := 0
+
+	for _, b := range k {
+		key := b.display + "/" + b.label
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		rows = append(rows, row{display: b.display, help: b.help})
+		if w := lipgloss.Width(b.display); w > width {
+			width = w
+		}
+	}
+
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		pad := width - lipgloss.Width(r.display)
+		out = append(out, r.display+strings.Repeat(" ", pad)+"  —  "+r.help)
+	}
+	return out
+}
+
+// dispatch returns the handler for key, or nil when no binding claims it. The
+// first match wins, so an earlier binding shadows a later one.
+func (k keymap) dispatch(key string) func(Model, string) (Model, tea.Cmd) {
+	for _, b := range k {
+		if slices.Contains(b.keys, key) {
+			return b.handler
+		}
+	}
+	return nil
+}

--- a/internal/ui/tui/keymap_test.go
+++ b/internal/ui/tui/keymap_test.go
@@ -1,0 +1,130 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func noopHandler(m Model, _ string) (Model, tea.Cmd) { return m, nil }
+
+// navKeymap is the shape the dedupe rules exist for: two handlers, four keys,
+// one visible entry.
+func navKeymap() keymap {
+	return keymap{
+		{keys: []string{"up", "k"}, display: "↑↓", label: "Navigate",
+			help: "Move the cursor up", inBar: true, handler: noopHandler},
+		{keys: []string{"down", "j"}, display: "↑↓", label: "Navigate",
+			help: "Move the cursor down", inBar: true, handler: noopHandler},
+		{keys: []string{"enter"}, display: "Enter", label: "Run",
+			help: "Run the selected target", inBar: true, handler: noopHandler},
+		{keys: []string{"q", "ctrl+c"}, display: "q", label: "Quit",
+			help: "Quit mkx", handler: noopHandler},
+	}
+}
+
+func TestHintBarFormat(t *testing.T) {
+	got := ansi.Strip(navKeymap().hintBar())
+	want := "↑↓/Navigate  Enter/Run"
+
+	if got != want {
+		t.Errorf("hintBar() = %q, want %q", got, want)
+	}
+}
+
+func TestHintBarOmitsHelpOnlyBindings(t *testing.T) {
+	if got := ansi.Strip(navKeymap().hintBar()); strings.Contains(got, "Quit") {
+		t.Errorf("hintBar() included the inBar:false q/Quit binding: %q", got)
+	}
+}
+
+func TestHelpRowsIncludeHelpOnlyBindings(t *testing.T) {
+	rows := navKeymap().helpRows()
+
+	var found bool
+	for _, r := range rows {
+		if strings.Contains(r, "Quit mkx") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("helpRows() dropped the help-only q binding: %v", rows)
+	}
+}
+
+// Dedupe is what removes the need for an asymmetric suppression flag on the
+// down-arrow binding.
+func TestDedupeOnDisplayAndLabel(t *testing.T) {
+	k := navKeymap()
+
+	if got := strings.Count(ansi.Strip(k.hintBar()), "↑↓/Navigate"); got != 1 {
+		t.Errorf("hintBar() rendered ↑↓/Navigate %d times, want 1", got)
+	}
+
+	var navRows int
+	for _, r := range k.helpRows() {
+		if strings.HasPrefix(r, "↑↓") {
+			navRows++
+		}
+	}
+	if navRows != 1 {
+		t.Errorf("helpRows() rendered %d ↑↓ rows, want 1", navRows)
+	}
+}
+
+func TestHelpRowsAlignTheKeyColumn(t *testing.T) {
+	rows := navKeymap().helpRows()
+	if len(rows) == 0 {
+		t.Fatal("helpRows() returned nothing")
+	}
+
+	// Display columns, not byte offsets — "↑↓" is two columns and six bytes.
+	column := func(row string) int {
+		prefix, _, _ := strings.Cut(row, "—")
+		return lipgloss.Width(prefix)
+	}
+
+	want := column(rows[0])
+	for i, r := range rows {
+		if got := column(r); got != want {
+			t.Errorf("row %d puts the separator at column %d, want %d: %q", i, got, want, r)
+		}
+	}
+}
+
+func TestDispatchReturnsTheHandlerForEveryKey(t *testing.T) {
+	k := navKeymap()
+
+	for _, b := range k {
+		for _, key := range b.keys {
+			if k.dispatch(key) == nil {
+				t.Errorf("dispatch(%q) = nil, want the %q handler", key, b.label)
+			}
+		}
+	}
+}
+
+func TestDispatchReturnsNilForAnUnboundKey(t *testing.T) {
+	if navKeymap().dispatch("z") != nil {
+		t.Error(`dispatch("z") returned a handler for an unbound key`)
+	}
+}
+
+// The drift check the registry exists to make impossible, stated as an
+// invariant over an arbitrary keymap.
+func TestHelpIsASupersetOfTheHintBar(t *testing.T) {
+	k := navKeymap()
+	rows := strings.Join(k.helpRows(), "\n")
+
+	for _, b := range k {
+		if !b.inBar {
+			continue
+		}
+		if !strings.Contains(rows, b.display) {
+			t.Errorf("hint bar advertises %q but help does not document it", b.display)
+		}
+	}
+}

--- a/internal/ui/tui/keymap_views.go
+++ b/internal/ui/tui/keymap_views.go
@@ -31,7 +31,7 @@ func projectKeymap() keymap {
 				return m, nil
 			}},
 		{keys: []string{"enter"}, display: "Enter", label: "Targets",
-			help: "Open the selected project's target list", inBar: true,
+			help: "Open the project's target list", inBar: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				if len(m.projects) > 0 {
 					m.selectedProject = m.projectCursor
@@ -41,7 +41,7 @@ func projectKeymap() keymap {
 				return m, nil
 			}},
 		{keys: []string{"g"}, display: "g", label: "Pull",
-			help: "Git pull the selected project and re-read its targets", inBar: true,
+			help: "Git pull and re-read targets", inBar: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				if len(m.projects) == 0 {
 					return m, nil
@@ -49,7 +49,7 @@ func projectKeymap() keymap {
 				return m, m.pull(m.projectCursor)
 			}},
 		{keys: []string{"R"}, display: "R", label: "Readme",
-			help: "Show the selected project's README", inBar: true,
+			help: "Show the project's README", inBar: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				if len(m.projects) == 0 {
 					return m, nil
@@ -62,7 +62,7 @@ func projectKeymap() keymap {
 				return m, tea.Quit
 			}},
 		{keys: []string{"?"}, display: "?", label: "Help",
-			help: "Show the keys available in this view", inBar: true,
+			help: "Keys available in this view", inBar: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				return m.showModal(modalHelp, "Help", "Projects", modalInput{}, helpKeymap()), nil
 			}},
@@ -98,7 +98,7 @@ func targetKeymap() keymap {
 				return m, m.runTarget(proj, proj.Targets[m.targetCursor])
 			}},
 		{keys: []string{"g"}, display: "g", label: "Pull",
-			help: "Git pull this project and re-read its targets", inBar: true,
+			help: "Git pull and re-read targets", inBar: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				if _, ok := m.currentProject(); !ok {
 					return m, nil
@@ -106,7 +106,7 @@ func targetKeymap() keymap {
 				return m, m.pull(m.selectedProject)
 			}},
 		{keys: []string{"R"}, display: "R", label: "Readme",
-			help: "Show this project's README", inBar: true,
+			help: "Show the project's README", inBar: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				proj, ok := m.currentProject()
 				if !ok {
@@ -129,7 +129,7 @@ func targetKeymap() keymap {
 				return m, tea.Quit
 			}},
 		{keys: []string{"?"}, display: "?", label: "Help",
-			help: "Show the keys available in this view", inBar: true,
+			help: "Keys available in this view", inBar: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				proj, _ := m.currentProject()
 				return m.showModal(modalHelp, "Help", proj.Name, modalInput{}, helpKeymap()), nil

--- a/internal/ui/tui/keymap_views.go
+++ b/internal/ui/tui/keymap_views.go
@@ -1,0 +1,152 @@
+package tui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// The view keymaps. Each is the single declaration of what its view does:
+// what the hint bar advertises, what the help overlay documents, and what a
+// key press actually runs.
+//
+// `r` appears in neither. @UI Patterns reserves it for refresh across every
+// Taelron TUI, and a list backed by stable local data — MkX parses Make
+// targets once at startup — omits it rather than binding it to a no-op.
+
+func projectKeymap() keymap {
+	return keymap{
+		{keys: []string{"up", "k"}, display: "↑↓", label: "Navigate",
+			help: "Move the cursor up", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				if m.projectCursor > 0 {
+					m.projectCursor--
+				}
+				return m, nil
+			}},
+		{keys: []string{"down", "j"}, display: "↑↓", label: "Navigate",
+			help: "Move the cursor down", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				if m.projectCursor < len(m.projects)-1 {
+					m.projectCursor++
+				}
+				return m, nil
+			}},
+		{keys: []string{"enter"}, display: "Enter", label: "Targets",
+			help: "Open the selected project's target list", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				if len(m.projects) > 0 {
+					m.selectedProject = m.projectCursor
+					m.targetCursor = 0
+					m.view = viewTargets
+				}
+				return m, nil
+			}},
+		{keys: []string{"g"}, display: "g", label: "Pull",
+			help: "Git pull the selected project and re-read its targets", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				if len(m.projects) == 0 {
+					return m, nil
+				}
+				return m, m.pull(m.projectCursor)
+			}},
+		{keys: []string{"R"}, display: "R", label: "Readme",
+			help: "Show the selected project's README", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				if len(m.projects) == 0 {
+					return m, nil
+				}
+				return m, viewReadme(m.app.ReadmePath(m.rootCtx, m.projects[m.projectCursor]))
+			}},
+		{keys: []string{"q", "ctrl+c"}, display: "q", label: "Quit",
+			help: "Quit mkx", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				return m, tea.Quit
+			}},
+		{keys: []string{"?"}, display: "?", label: "Help",
+			help: "Show the keys available in this view", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				return m.showModal(modalHelp, "Help", "Projects", modalInput{}, helpKeymap()), nil
+			}},
+	}
+}
+
+func targetKeymap() keymap {
+	return keymap{
+		{keys: []string{"up", "k"}, display: "↑↓", label: "Navigate",
+			help: "Move the cursor up", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				if m.targetCursor > 0 {
+					m.targetCursor--
+				}
+				return m, nil
+			}},
+		{keys: []string{"down", "j"}, display: "↑↓", label: "Navigate",
+			help: "Move the cursor down", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				proj, ok := m.currentProject()
+				if ok && m.targetCursor < len(proj.Targets)-1 {
+					m.targetCursor++
+				}
+				return m, nil
+			}},
+		{keys: []string{"enter"}, display: "Enter", label: "Run",
+			help: "Run the selected target", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				proj, ok := m.currentProject()
+				if !ok || len(proj.Targets) == 0 {
+					return m, nil
+				}
+				return m, m.runTarget(proj, proj.Targets[m.targetCursor])
+			}},
+		{keys: []string{"g"}, display: "g", label: "Pull",
+			help: "Git pull this project and re-read its targets", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				if _, ok := m.currentProject(); !ok {
+					return m, nil
+				}
+				return m, m.pull(m.selectedProject)
+			}},
+		{keys: []string{"R"}, display: "R", label: "Readme",
+			help: "Show this project's README", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				proj, ok := m.currentProject()
+				if !ok {
+					return m, nil
+				}
+				return m, viewReadme(m.app.ReadmePath(m.rootCtx, proj))
+			}},
+		{keys: []string{"esc"}, display: "Esc", label: "Back",
+			help: "Back to the project list", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				m.view = viewProjects
+				m.lastRun = nil
+				return m, nil
+			}},
+		// Help-only: the hint bar's last two slots are the prescribed
+		// Esc/Back  ?/Help, so q does not claim one.
+		{keys: []string{"q", "ctrl+c"}, display: "q", label: "Quit",
+			help: "Quit mkx",
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				return m, tea.Quit
+			}},
+		{keys: []string{"?"}, display: "?", label: "Help",
+			help: "Show the keys available in this view", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				proj, _ := m.currentProject()
+				return m.showModal(modalHelp, "Help", proj.Name, modalInput{}, helpKeymap()), nil
+			}},
+	}
+}
+
+// helpKeymap is the help overlay's own bindings — the keys that reach the
+// modal while it is up, and the modal's hint bar.
+func helpKeymap() keymap {
+	closeHelp := func(m Model, _ string) (Model, tea.Cmd) {
+		return m.closeModal(), nil
+	}
+	return keymap{
+		{keys: []string{"esc"}, display: "Esc", label: "Close",
+			help: "Close this overlay", inBar: true, handler: closeHelp},
+		{keys: []string{"?"}, display: "?", label: "Close",
+			help: "Close this overlay", inBar: true, handler: closeHelp},
+	}
+}

--- a/internal/ui/tui/modal.go
+++ b/internal/ui/tui/modal.go
@@ -1,0 +1,165 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/ui/tui/styles"
+)
+
+// modalContent identifies which content type a modal is showing. The frame —
+// centring, border, dimming, key interception — is shared; only the content
+// area varies.
+type modalContent int
+
+const (
+	modalNone modalContent = iota
+	modalHelp
+	// The M2 branch picker lands here, and costs one enum value, one
+	// renderModalBody case, one keymap func and one showModal call.
+)
+
+// modalInput is the cursor and text state interactive content types need. Info
+// content (the help overlay) leaves it zero.
+type modalInput struct {
+	cursor int
+	text   string
+}
+
+// modalState is the modal overlay's whole state. Its zero value is inactive,
+// so a Model needs no wiring to start without a modal.
+type modalState struct {
+	active  bool
+	content modalContent
+	title   string
+	// context is right-aligned in the header: the view name, "Step 1/3", …
+	context string
+	// keys are the modal's own bindings. They intercept all dispatch while it
+	// is active, and they render as the modal's hint bar — which is why the
+	// help overlay can show Esc/Close  ?/Close where an interactive content
+	// type shows the prescribed Enter/Confirm  Esc/Cancel.
+	keys  keymap
+	input modalInput
+}
+
+// showModal opens a modal over the current view.
+func (m Model) showModal(c modalContent, title, context string, in modalInput, k keymap) Model {
+	m.modal = modalState{
+		active:  true,
+		content: c,
+		title:   title,
+		context: context,
+		keys:    k,
+		input:   in,
+	}
+	return m
+}
+
+// closeModal returns to the underlying view, which was never modified while
+// the modal was up.
+func (m Model) closeModal() Model {
+	m.modal = modalState{}
+	return m
+}
+
+// modalMaxInnerWidth is the widest content area a modal may use: ~60% of the
+// terminal, less the border (2) and the horizontal padding (2).
+func (m Model) modalMaxInnerWidth() int {
+	w := m.width
+	if w < 20 {
+		w = 80
+	}
+	return max(w*60/100-4, modalMinInnerWidth)
+}
+
+const modalMinInnerWidth = 20
+
+// buildModalBox renders the frame around a body:
+//
+//	╭─────────────────────────────────╮
+//	│ Title                   Context │
+//	│─────────────────────────────────│
+//	│ [body]                          │
+//	│─────────────────────────────────│
+//	│ key/Action  key/Action          │
+//	╰─────────────────────────────────╯
+//
+// The inner width is the widest of header, body and hint bar, capped at
+// maxInner. Body lines wider than that truncate with an ellipsis; there is
+// deliberately no height clamp, because modals never scroll — content that
+// cannot fit is the wrong pattern.
+func buildModalBox(title, context, body, hints string, maxInner int) string {
+	header := title
+	if context != "" {
+		header = title + "  " + context
+	}
+
+	bodyLines := strings.Split(body, "\n")
+
+	inner := lipgloss.Width(header)
+	for _, line := range bodyLines {
+		inner = max(inner, lipgloss.Width(line))
+	}
+	inner = max(inner, lipgloss.Width(hints))
+	inner = min(max(inner, modalMinInnerWidth), maxInner)
+
+	// Header: title left, context hard right.
+	styledHeader := styles.ModalTitle.Render(title)
+	if context != "" {
+		gap := max(inner-lipgloss.Width(title)-lipgloss.Width(context), 1)
+		styledHeader += strings.Repeat(" ", gap) + styles.ModalContext.Render(context)
+	}
+
+	rule := styles.ModalRule.Render(strings.Repeat("─", inner))
+
+	for i, line := range bodyLines {
+		if lipgloss.Width(line) > inner {
+			line = ansi.TruncateWc(line, inner, "…")
+		}
+		bodyLines[i] = styles.ModalBody.Render(line)
+	}
+
+	parts := make([]string, 0, len(bodyLines)+4)
+	parts = append(parts, styledHeader, rule)
+	parts = append(parts, bodyLines...)
+	parts = append(parts, rule, hints)
+
+	// Width is set on the padded content area, so the outer box comes to
+	// inner + 2 padding + 2 border columns.
+	return styles.ModalBorder.Width(inner + 2).Render(strings.Join(parts, "\n"))
+}
+
+// renderModalBody renders the content area for the active content type. Each
+// new modal adds exactly one case here.
+func (m Model) renderModalBody(maxWidth int) string {
+	switch m.modal.content {
+	case modalNone:
+		return ""
+	}
+	return ""
+}
+
+// renderModal composites the modal over an already-rendered view: dim the
+// background, centre the box, splice it on.
+//
+// Lipgloss v1 has no Canvas/Layer, and lipgloss.Place centres onto a
+// whitespace canvas that would overwrite the dimmed background, so the offsets
+// are computed explicitly. @UI Patterns specifies the outcome — a centred,
+// bordered modal over a visibly dimmed view — and leaves the mechanic to the
+// product.
+func (m Model) renderModal(base string) string {
+	box := buildModalBox(
+		m.modal.title,
+		m.modal.context,
+		m.renderModalBody(m.modalMaxInnerWidth()),
+		m.modal.keys.hintBar(),
+		m.modalMaxInnerWidth(),
+	)
+
+	x := max((m.width-lipgloss.Width(box))/2, 0)
+	y := max((m.height-lipgloss.Height(box))/2, 0)
+
+	return splice(dimBackground(base), box, x, y)
+}

--- a/internal/ui/tui/modal.go
+++ b/internal/ui/tui/modal.go
@@ -133,10 +133,12 @@ func buildModalBox(title, context, body, hints string, maxInner int) string {
 
 // renderModalBody renders the content area for the active content type. Each
 // new modal adds exactly one case here.
-func (m Model) renderModalBody(maxWidth int) string {
+func (m Model) renderModalBody() string {
 	switch m.modal.content {
-	case modalNone:
-		return ""
+	case modalHelp:
+		// The underlying view's keymap, not the modal's own — that is what
+		// makes help context-sensitive.
+		return renderHelpBody(m.viewKeymap())
 	}
 	return ""
 }
@@ -153,7 +155,7 @@ func (m Model) renderModal(base string) string {
 	box := buildModalBox(
 		m.modal.title,
 		m.modal.context,
-		m.renderModalBody(m.modalMaxInnerWidth()),
+		m.renderModalBody(),
 		m.modal.keys.hintBar(),
 		m.modalMaxInnerWidth(),
 	)

--- a/internal/ui/tui/modal.go
+++ b/internal/ui/tui/modal.go
@@ -76,6 +76,17 @@ func (m Model) modalMaxInnerWidth() int {
 
 const modalMinInnerWidth = 20
 
+// clampWidth truncates s to w display columns, marking the cut with an
+// ellipsis. Every line inside a modal goes through it: lipgloss word-wraps
+// rather than truncates when a line exceeds the style's width, which would
+// silently change the box's height.
+func clampWidth(s string, w int) string {
+	if lipgloss.Width(s) <= w {
+		return s
+	}
+	return ansi.TruncateWc(s, w, "…")
+}
+
 // buildModalBox renders the frame around a body:
 //
 //	╭─────────────────────────────────╮
@@ -105,6 +116,21 @@ func buildModalBox(title, context, body, hints string, maxInner int) string {
 	inner = max(inner, lipgloss.Width(hints))
 	inner = min(max(inner, modalMinInnerWidth), maxInner)
 
+	// Header and hint bar are clamped to inner just as body lines are. Without
+	// this, lipgloss word-wraps the over-wide line inside the border — a long
+	// project name in the header would split across two rows and push
+	// everything below it down. A deeply nested project path reaches this at
+	// 80 columns, where inner is only 44.
+	title = clampWidth(title, inner)
+	if context != "" {
+		if room := inner - lipgloss.Width(title) - 2; room < 1 {
+			context = ""
+		} else {
+			context = clampWidth(context, room)
+		}
+	}
+	hints = clampWidth(hints, inner)
+
 	// Header: title left, context hard right.
 	styledHeader := styles.ModalTitle.Render(title)
 	if context != "" {
@@ -115,10 +141,7 @@ func buildModalBox(title, context, body, hints string, maxInner int) string {
 	rule := styles.ModalRule.Render(strings.Repeat("─", inner))
 
 	for i, line := range bodyLines {
-		if lipgloss.Width(line) > inner {
-			line = ansi.TruncateWc(line, inner, "…")
-		}
-		bodyLines[i] = styles.ModalBody.Render(line)
+		bodyLines[i] = styles.ModalBody.Render(clampWidth(line, inner))
 	}
 
 	parts := make([]string, 0, len(bodyLines)+4)

--- a/internal/ui/tui/modal_help.go
+++ b/internal/ui/tui/modal_help.go
@@ -1,0 +1,19 @@
+package tui
+
+import (
+	"strings"
+)
+
+// renderHelpBody renders the help overlay's content: the keys available in the
+// view the overlay was opened over, as "key — action" rows.
+//
+// It takes the view's own keymap rather than a global reference, which is what
+// makes help context-sensitive per @UI Patterns. Nothing else derives the rows,
+// so a key can neither appear here without a handler nor be handled without
+// appearing here.
+//
+// Rows are not clamped: buildModalBox owns the width, and truncating twice
+// would just hide which one did it.
+func renderHelpBody(k keymap) string {
+	return strings.Join(k.helpRows(), "\n")
+}

--- a/internal/ui/tui/modal_help_test.go
+++ b/internal/ui/tui/modal_help_test.go
@@ -1,0 +1,128 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// helpView opens the help overlay over the named view and returns the full
+// rendered screen.
+func helpView(t *testing.T, v view) string {
+	t.Helper()
+
+	m := testModel()
+	m.view = v
+
+	opened, _ := m.viewKeymap().dispatch("?")(m, "?")
+	if !opened.modal.active {
+		t.Fatal("`?` did not open the help overlay")
+	}
+	return opened.View()
+}
+
+// Help lists the keys of the view it was opened over, not a global reference.
+// Derived from the view's own keymap, so this checks the wiring rather than
+// restating it.
+func TestHelpIsContextSensitive(t *testing.T) {
+	projects := ansi.Strip(helpView(t, viewProjects))
+	targets := ansi.Strip(helpView(t, viewTargets))
+
+	if !strings.Contains(projects, "Open the project's target list") {
+		t.Error("the project view's help is missing Enter/Targets")
+	}
+	if strings.Contains(projects, "Run the selected target") {
+		t.Error("the project view's help documents the target view's Enter")
+	}
+	if strings.Contains(projects, "Back to the project list") {
+		t.Error("the project view's help documents Esc/Back, which the root view has no use for")
+	}
+
+	if !strings.Contains(targets, "Run the selected target") {
+		t.Error("the target view's help is missing Enter/Run")
+	}
+	if !strings.Contains(targets, "Back to the project list") {
+		t.Error("the target view's help is missing Esc/Back")
+	}
+	if strings.Contains(targets, "Open the project's target list") {
+		t.Error("the target view's help documents the project view's Enter")
+	}
+}
+
+// The removal, seen from the surface the user actually reads.
+func TestHelpDocumentsNoRunKeyBesidesEnter(t *testing.T) {
+	body := renderHelpBody(targetKeymap())
+
+	for _, row := range strings.Split(body, "\n") {
+		if strings.HasPrefix(row, "r ") || strings.HasPrefix(row, "r—") {
+			t.Errorf("help still documents an `r` key: %q", row)
+		}
+	}
+	if !strings.Contains(body, "Run the selected target") {
+		t.Error("help does not document Enter as the run key")
+	}
+}
+
+// q is deliberately absent from the target view's hint bar, so help is the only
+// place it is documented.
+func TestHelpDocumentsTheHelpOnlyQuitKey(t *testing.T) {
+	if !strings.Contains(ansi.Strip(helpView(t, viewTargets)), "Quit mkx") {
+		t.Error("the target view's help is missing q/Quit")
+	}
+}
+
+// The modal advertises Esc/Close  ?/Close rather than the baseline's
+// Enter/Confirm  Esc/Cancel: info content has nothing to confirm, and a bar
+// advertising a no-op Enter is worse than one that omits it.
+func TestHelpModalHintBar(t *testing.T) {
+	if got := ansi.Strip(helpKeymap().hintBar()); got != "Esc/Close  ?/Close" {
+		t.Errorf("help modal hint bar = %q, want %q", got, "Esc/Close  ?/Close")
+	}
+}
+
+// The load-bearing 80×24 check. Step 13 of the PR's visual sequence is the
+// aesthetic counterpart; this is the one that can fail a build.
+func TestHelpFitsAtEightyByTwentyFour(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		v    view
+	}{{"projects", viewProjects}, {"targets", viewTargets}} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := helpView(t, tc.v)
+			lines := strings.Split(out, "\n")
+
+			if len(lines) > 24 {
+				t.Errorf("rendered %d lines at height 24", len(lines))
+			}
+			for i, line := range lines {
+				if w := lipgloss.Width(line); w > 80 {
+					t.Errorf("line %d is %d columns wide at width 80: %q", i, w, ansi.Strip(line))
+				}
+			}
+
+			// Nothing actually truncates. A future verbose help string fails
+			// the suite instead of silently clipping.
+			if strings.Contains(ansi.Strip(out), "…") {
+				t.Error("a help row was truncated at 80×24; shorten it or raise the width cap")
+			}
+		})
+	}
+}
+
+// Every key the hint bar advertises is also documented in help, for the real
+// view keymaps rather than a fixture.
+func TestViewHelpIsASupersetOfTheViewHintBar(t *testing.T) {
+	for name, k := range viewKeymaps() {
+		rows := renderHelpBody(k)
+		for _, b := range k {
+			if !b.inBar {
+				continue
+			}
+			if !strings.Contains(rows, b.display) {
+				t.Errorf("%s view: hint bar shows %q but help does not document it", name, b.display)
+			}
+		}
+	}
+}

--- a/internal/ui/tui/modal_test.go
+++ b/internal/ui/tui/modal_test.go
@@ -1,0 +1,160 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestBuildModalBoxStructure(t *testing.T) {
+	box := buildModalBox("Help", "Targets", "one\ntwo", "Esc/Close", 44)
+	lines := strings.Split(ansi.Strip(box), "\n")
+
+	// border, header, rule, 2 body, rule, hints, border
+	if len(lines) != 8 {
+		t.Fatalf("box has %d lines, want 8:\n%s", len(lines), ansi.Strip(box))
+	}
+	if !strings.HasPrefix(lines[0], "╭") || !strings.HasSuffix(lines[0], "╮") {
+		t.Errorf("top border is not rounded: %q", lines[0])
+	}
+	if !strings.HasPrefix(lines[7], "╰") || !strings.HasSuffix(lines[7], "╯") {
+		t.Errorf("bottom border is not rounded: %q", lines[7])
+	}
+	if !strings.Contains(lines[1], "Help") || !strings.Contains(lines[1], "Targets") {
+		t.Errorf("header is missing the title or the context: %q", lines[1])
+	}
+	if !strings.Contains(lines[6], "Esc/Close") {
+		t.Errorf("hint bar row is missing the hints: %q", lines[6])
+	}
+}
+
+func TestBuildModalBoxIsRectangular(t *testing.T) {
+	box := buildModalBox("Help", "Targets", "short\na much longer body line", "Esc/Close", 44)
+
+	lines := strings.Split(box, "\n")
+	want := lipgloss.Width(lines[0])
+	for i, line := range lines {
+		if got := lipgloss.Width(line); got != want {
+			t.Errorf("line %d width = %d, want %d: %q", i, got, want, ansi.Strip(line))
+		}
+	}
+}
+
+// The context is right-aligned in the header, per the UI Patterns box
+// structure.
+func TestBuildModalBoxRightAlignsTheContext(t *testing.T) {
+	box := buildModalBox("Help", "Targets", "body", "Esc/Close", 44)
+	header := strings.Split(ansi.Strip(box), "\n")[1]
+
+	if !strings.HasSuffix(strings.TrimRight(header, " │"), "Targets") {
+		t.Errorf("context is not flush right in the header: %q", header)
+	}
+}
+
+func TestBuildModalBoxCapsTheInnerWidth(t *testing.T) {
+	const maxInner = 44
+	box := buildModalBox("Help", "", strings.Repeat("x", 200), "Esc/Close", maxInner)
+
+	// inner + 2 padding + 2 border
+	if got := lipgloss.Width(box); got != maxInner+4 {
+		t.Errorf("box width = %d, want %d", got, maxInner+4)
+	}
+	if !strings.Contains(ansi.Strip(box), "…") {
+		t.Error("an over-wide body line was not truncated with an ellipsis")
+	}
+}
+
+func TestBuildModalBoxHasAMinimumWidth(t *testing.T) {
+	box := buildModalBox("H", "", "x", "y", 44)
+
+	if got := lipgloss.Width(box); got != modalMinInnerWidth+4 {
+		t.Errorf("narrow box width = %d, want %d", got, modalMinInnerWidth+4)
+	}
+}
+
+func TestModalMaxInnerWidthIsSixtyPercent(t *testing.T) {
+	// 80 columns → 48 outer, 44 inner.
+	if got := (Model{width: 80}).modalMaxInnerWidth(); got != 44 {
+		t.Errorf("modalMaxInnerWidth() at 80 columns = %d, want 44", got)
+	}
+	// An unset width falls back to 80, as the list renderers do.
+	if got := (Model{}).modalMaxInnerWidth(); got != 44 {
+		t.Errorf("modalMaxInnerWidth() with no size = %d, want 44", got)
+	}
+}
+
+func TestShowModalAndCloseModal(t *testing.T) {
+	m := Model{}
+
+	m = m.showModal(modalHelp, "Help", "Projects", modalInput{}, keymap{
+		{keys: []string{"esc"}, display: "Esc", label: "Close", inBar: true},
+	})
+	if !m.modal.active {
+		t.Fatal("showModal did not activate the modal")
+	}
+	if m.modal.content != modalHelp || m.modal.title != "Help" || m.modal.context != "Projects" {
+		t.Errorf("showModal did not carry the content type, title and context: %+v", m.modal)
+	}
+
+	m = m.closeModal()
+	if m.modal.active {
+		t.Error("closeModal left the modal active")
+	}
+	if m.modal.content != modalNone {
+		t.Errorf("closeModal left content = %v, want modalNone", m.modal.content)
+	}
+}
+
+// The composite: the box sits centred over a background that is still visible
+// but no longer carries its own attributes.
+func TestRenderModalCompositesOverADimmedBackground(t *testing.T) {
+	base := strings.TrimSuffix(strings.Repeat(strings.Repeat("·", 80)+"\n", 23), "\n")
+
+	m := Model{width: 80, height: 24}
+	m = m.showModal(modalHelp, "Help", "Targets", modalInput{}, keymap{
+		{keys: []string{"esc"}, display: "Esc", label: "Close", inBar: true},
+	})
+
+	out := ansi.Strip(m.renderModal(base))
+	lines := strings.Split(out, "\n")
+
+	if len(lines) != 23 {
+		t.Fatalf("composite has %d lines, want the background's 23", len(lines))
+	}
+	for i, line := range lines {
+		if got := lipgloss.Width(line); got != 80 {
+			t.Errorf("line %d width = %d, want 80", i, got)
+		}
+	}
+
+	// The background survives either side of the box on the rows it covers.
+	var boxRow int
+	for i, line := range lines {
+		if strings.Contains(line, "╭") {
+			boxRow = i
+		}
+	}
+	if boxRow == 0 {
+		t.Fatal("no top border found in the composite")
+	}
+	if !strings.HasPrefix(lines[boxRow], "·") || !strings.HasSuffix(lines[boxRow], "·") {
+		t.Errorf("the box overwrote the background either side of itself: %q", lines[boxRow])
+	}
+
+	// Centred: equal background either side, to within a column.
+	left := len(lines[boxRow]) - len(strings.TrimLeft(lines[boxRow], "·"))
+	right := len(lines[boxRow]) - len(strings.TrimRight(lines[boxRow], "·"))
+	if left-right > 1 || right-left > 1 {
+		t.Errorf("box is not centred: %d columns left, %d right", left, right)
+	}
+}
+
+func TestViewRendersTheBaseWhenNoModalIsActive(t *testing.T) {
+	m := Model{width: 80, height: 24}
+
+	if strings.Contains(m.View(), "╭") {
+		t.Error("View() drew a modal frame with no modal active")
+	}
+}

--- a/internal/ui/tui/modal_test.go
+++ b/internal/ui/tui/modal_test.go
@@ -66,6 +66,40 @@ func TestBuildModalBoxCapsTheInnerWidth(t *testing.T) {
 	}
 }
 
+// Lipgloss word-wraps rather than truncates when a line exceeds the style's
+// width, so an over-wide header or hint bar silently makes the box a row
+// taller and breaks the single-line header the box structure specifies. A
+// deeply nested project path reaches this at 80 columns, where inner is 44.
+func TestBuildModalBoxClampsTheHeaderAndHintBar(t *testing.T) {
+	const maxInner = 44
+
+	tests := []struct {
+		name                  string
+		title, context, hints string
+	}{
+		{"long context", "Help", "deep/level2/level3/level4/level5/level6/level7", "Esc/Close"},
+		{"long title", strings.Repeat("T", 90), "", "Esc/Close"},
+		{"long hint bar", "Help", "x", "Enter/Confirm  Esc/Cancel  Space/Toggle  Tab/Next  ?/Help  q/Quit"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			box := buildModalBox(tt.title, tt.context, "body", tt.hints, maxInner)
+			lines := strings.Split(box, "\n")
+
+			// border, header, rule, body, rule, hints, border
+			if len(lines) != 7 {
+				t.Errorf("box has %d lines, want 7 — a line wrapped:\n%s", len(lines), ansi.Strip(box))
+			}
+			for i, line := range lines {
+				if w := lipgloss.Width(line); w != maxInner+4 {
+					t.Errorf("line %d width = %d, want %d: %q", i, w, maxInner+4, ansi.Strip(line))
+				}
+			}
+		})
+	}
+}
+
 func TestBuildModalBoxHasAMinimumWidth(t *testing.T) {
 	box := buildModalBox("H", "", "x", "y", 44)
 

--- a/internal/ui/tui/model.go
+++ b/internal/ui/tui/model.go
@@ -236,12 +236,11 @@ func (m Model) View() string {
 	return ""
 }
 
-func (m Model) renderHintBar(hints [][]string) string {
-	var parts []string
-	for _, h := range hints {
-		parts = append(parts, styles.HintKey.Render("<"+h[0]+">")+" "+styles.HintAction.Render(h[1]))
-	}
-	bar := strings.Join(parts, "  ")
+// renderHintBar renders a view's keymap as the bottom bar, with any flash
+// message appended. The key/Action formatting lives on keymap.hintBar; this
+// function only owns the flash and the bar's width.
+func (m Model) renderHintBar(k keymap) string {
+	bar := k.hintBar()
 	if m.flash != "" {
 		bar += "  " + styles.Flash.Render(m.flash)
 	}
@@ -372,11 +371,11 @@ func (m Model) renderProjectList() string {
 	}
 
 	s += styles.Border.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
-	s += m.renderHintBar([][]string{
-		{"Enter", "Drill In"},
-		{"g", "Pull"},
-		{"?", "Readme"},
-		{"q", "Quit"},
+	s += m.renderHintBar(keymap{
+		{display: "Enter", label: "Drill In", inBar: true},
+		{display: "g", label: "Pull", inBar: true},
+		{display: "?", label: "Readme", inBar: true},
+		{display: "q", label: "Quit", inBar: true},
 	})
 	return s
 }
@@ -458,11 +457,11 @@ func (m Model) renderTargetList() string {
 
 	s += styles.Border.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
 
-	hints := [][]string{
-		{"r", "Run"},
-		{"g", "Pull"},
-		{"?", "Readme"},
-		{"Esc", "Back"},
+	hints := keymap{
+		{display: "r", label: "Run", inBar: true},
+		{display: "g", label: "Pull", inBar: true},
+		{display: "?", label: "Readme", inBar: true},
+		{display: "Esc", label: "Back", inBar: true},
 	}
 	if m.lastRun != nil {
 		status := "✓"

--- a/internal/ui/tui/model.go
+++ b/internal/ui/tui/model.go
@@ -53,6 +53,9 @@ type Model struct {
 	// flash message
 	flash string
 
+	// modal overlay; the zero value is inactive
+	modal modalState
+
 	// terminal size
 	width  int
 	height int
@@ -227,13 +230,18 @@ func (m Model) pull(projectIndex int) tea.Cmd {
 }
 
 func (m Model) View() string {
+	var base string
 	switch m.view {
 	case viewProjects:
-		return m.renderProjectList()
+		base = m.renderProjectList()
 	case viewTargets:
-		return m.renderTargetList()
+		base = m.renderTargetList()
 	}
-	return ""
+
+	if m.modal.active {
+		return m.renderModal(base)
+	}
+	return base
 }
 
 // renderHintBar renders a view's keymap as the bottom bar, with any flash

--- a/internal/ui/tui/model.go
+++ b/internal/ui/tui/model.go
@@ -121,76 +121,51 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// handleKey is the only path from a tea.KeyMsg into the model, which is what
+// makes the modal interception below total: no key can reach a view's bindings
+// while a modal is up, because the view keymap is only consulted past the early
+// return.
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+
+	if m.modal.active {
+		if h := m.modal.keys.dispatch(key); h != nil {
+			return h(m, key)
+		}
+		// An unbound key inside a modal is a no-op, never a fall-through.
+		return m, nil
+	}
+
+	// Below the interception, so keys pressed inside a modal do not clear a
+	// flash that is hidden behind it anyway.
 	m.flash = ""
+
+	if h := m.viewKeymap().dispatch(key); h != nil {
+		return h(m, key)
+	}
+	return m, nil
+}
+
+// viewKeymap returns the current view's bindings — the single source for its
+// key dispatch, its hint bar and its help overlay.
+func (m Model) viewKeymap() keymap {
 	switch m.view {
 	case viewProjects:
-		return m.handleProjectKeys(msg)
+		return projectKeymap()
 	case viewTargets:
-		return m.handleTargetKeys(msg)
+		return targetKeymap()
 	}
-	return m, nil
+	return nil
 }
 
-func (m Model) handleProjectKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "q", "ctrl+c":
-		return m, tea.Quit
-	case "up", "k":
-		if m.projectCursor > 0 {
-			m.projectCursor--
-		}
-	case "down", "j":
-		if m.projectCursor < len(m.projects)-1 {
-			m.projectCursor++
-		}
-	case "enter":
-		if len(m.projects) > 0 {
-			m.selectedProject = m.projectCursor
-			m.targetCursor = 0
-			m.view = viewTargets
-		}
-	case "?":
-		if len(m.projects) > 0 {
-			m.flash = ""
-			return m, viewReadme(m.app.ReadmePath(m.rootCtx, m.projects[m.projectCursor]))
-		}
-	case "g":
-		if len(m.projects) > 0 {
-			return m, m.pull(m.projectCursor)
-		}
+// currentProject returns the project the target view is showing. The false
+// return covers a Model whose selectedProject is out of range, which the
+// bindings guard rather than panicking on.
+func (m Model) currentProject() (domain.Project, bool) {
+	if m.selectedProject < 0 || m.selectedProject >= len(m.projects) {
+		return domain.Project{}, false
 	}
-	return m, nil
-}
-
-func (m Model) handleTargetKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	proj := m.projects[m.selectedProject]
-
-	switch msg.String() {
-	case "q", "ctrl+c":
-		return m, tea.Quit
-	case "esc":
-		m.view = viewProjects
-		m.lastRun = nil
-	case "up", "k":
-		if m.targetCursor > 0 {
-			m.targetCursor--
-		}
-	case "down", "j":
-		if m.targetCursor < len(proj.Targets)-1 {
-			m.targetCursor++
-		}
-	case "r", "enter":
-		if len(proj.Targets) > 0 {
-			return m, m.runTarget(proj, proj.Targets[m.targetCursor])
-		}
-	case "?":
-		m.flash = ""
-		return m, viewReadme(m.app.ReadmePath(m.rootCtx, proj))
-	case "g":
-		return m, m.pull(m.selectedProject)
-	}
-	return m, nil
+	return m.projects[m.selectedProject], true
 }
 
 // runTarget asks the app for the command that runs t, then hands the terminal
@@ -379,12 +354,7 @@ func (m Model) renderProjectList() string {
 	}
 
 	s += styles.Border.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
-	s += m.renderHintBar(keymap{
-		{display: "Enter", label: "Drill In", inBar: true},
-		{display: "g", label: "Pull", inBar: true},
-		{display: "?", label: "Readme", inBar: true},
-		{display: "q", label: "Quit", inBar: true},
-	})
+	s += m.renderHintBar(projectKeymap())
 	return s
 }
 
@@ -465,12 +435,6 @@ func (m Model) renderTargetList() string {
 
 	s += styles.Border.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
 
-	hints := keymap{
-		{display: "r", label: "Run", inBar: true},
-		{display: "g", label: "Pull", inBar: true},
-		{display: "?", label: "Readme", inBar: true},
-		{display: "Esc", label: "Back", inBar: true},
-	}
 	if m.lastRun != nil {
 		status := "✓"
 		if m.lastRun.ExitCode != 0 {
@@ -478,6 +442,6 @@ func (m Model) renderTargetList() string {
 		}
 		m.flash = fmt.Sprintf("%s %s", status, m.lastRun.Duration.Round(time.Second))
 	}
-	s += m.renderHintBar(hints)
+	s += m.renderHintBar(targetKeymap())
 	return s
 }

--- a/internal/ui/tui/model_test.go
+++ b/internal/ui/tui/model_test.go
@@ -1,0 +1,251 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/app"
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+)
+
+// fakeScanner and fakeRunner stand in for the filesystem and Make. The key
+// bindings only need an App that answers without touching either.
+type fakeScanner struct{ readme string }
+
+func (f fakeScanner) Scan(context.Context, string) ([]domain.Project, error) {
+	return nil, nil
+}
+func (f fakeScanner) ReadmePath(context.Context, string) string { return f.readme }
+
+type fakeRunner struct{}
+
+func (fakeRunner) Discover(context.Context, string) ([]domain.Target, error) { return nil, nil }
+func (fakeRunner) TargetCommand(_ context.Context, dir, name string) domain.Command {
+	return domain.Command{Argv: []string{"make", name}, WorkDir: dir}
+}
+
+// testModel is a Model on the target list of a project with two targets,
+// cursor parked on the second.
+func testModel() Model {
+	return Model{
+		app:     app.New(fakeScanner{readme: "/tmp/README.md"}, fakeRunner{}),
+		rootCtx: context.Background(),
+		projects: []domain.Project{{
+			Name: "alpha",
+			Path: "/tmp/alpha",
+			Targets: []domain.Target{
+				{Name: "build", Description: "Compile"},
+				{Name: "test", Description: "Run tests"},
+			},
+		}},
+		view:            viewTargets,
+		selectedProject: 0,
+		targetCursor:    1,
+		width:           80,
+		height:          24,
+	}
+}
+
+func viewKeymaps() map[string]keymap {
+	return map[string]keymap{
+		"projects": projectKeymap(),
+		"targets":  targetKeymap(),
+	}
+}
+
+// A documented key that lost its handler fails here.
+func TestEveryBindingDispatches(t *testing.T) {
+	for name, k := range viewKeymaps() {
+		for _, b := range k {
+			for _, key := range b.keys {
+				if k.dispatch(key) == nil {
+					t.Errorf("%s view: dispatch(%q) = nil for the %q binding", name, key, b.label)
+				}
+			}
+		}
+	}
+}
+
+// `r` used to run the selected target. @UI Patterns reserves it for refresh,
+// so it is unbound — asserted, so a future re-bind is a deliberate act.
+func TestRIsUnbound(t *testing.T) {
+	for name, k := range viewKeymaps() {
+		if k.dispatch("r") != nil {
+			t.Errorf("%s view: `r` is bound again; @UI Patterns reserves it for refresh", name)
+		}
+		for _, b := range k {
+			if b.display == "r" {
+				t.Errorf("%s view: a binding still displays as `r` (%q)", name, b.label)
+			}
+		}
+	}
+}
+
+func TestHintBarsMatchTheBaselineFormats(t *testing.T) {
+	tests := []struct {
+		name string
+		k    keymap
+		want string
+	}{
+		{
+			name: "projects",
+			k:    projectKeymap(),
+			want: "↑↓/Navigate  Enter/Targets  g/Pull  R/Readme  q/Quit  ?/Help",
+		},
+		{
+			name: "targets",
+			k:    targetKeymap(),
+			want: "↑↓/Navigate  Enter/Run  g/Pull  R/Readme  Esc/Back  ?/Help",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ansi.Strip(tt.k.hintBar()); got != tt.want {
+				t.Errorf("hintBar() = %q\nwant           %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// q is reachable and documented in the target view, but does not claim one of
+// the bar's last two slots, which the baseline gives to Esc/Back and ?/Help.
+func TestQuitIsHelpOnlyInTheTargetView(t *testing.T) {
+	k := targetKeymap()
+
+	if strings.Contains(ansi.Strip(k.hintBar()), "Quit") {
+		t.Error("target hint bar carries q/Quit; it should be help-only")
+	}
+	if k.dispatch("q") == nil {
+		t.Error("q is not dispatched in the target view")
+	}
+	if !strings.Contains(strings.Join(k.helpRows(), "\n"), "Quit mkx") {
+		t.Error("q/Quit is missing from the target view's help rows")
+	}
+}
+
+func TestQuestionMarkOpensHelpRatherThanTheReadme(t *testing.T) {
+	for name, k := range viewKeymaps() {
+		h := k.dispatch("?")
+		if h == nil {
+			t.Fatalf("%s view: `?` is unbound", name)
+		}
+
+		got, cmd := h(testModel(), "?")
+		if !got.modal.active {
+			t.Errorf("%s view: `?` did not open a modal", name)
+		}
+		if got.modal.content != modalHelp {
+			t.Errorf("%s view: `?` opened content %v, want modalHelp", name, got.modal.content)
+		}
+		if cmd != nil {
+			t.Errorf("%s view: `?` issued a command; the README handover moved to R", name)
+		}
+	}
+}
+
+func TestCapitalRShowsTheReadme(t *testing.T) {
+	for name, k := range viewKeymaps() {
+		h := k.dispatch("R")
+		if h == nil {
+			t.Fatalf("%s view: `R` is unbound", name)
+		}
+
+		got, cmd := h(testModel(), "R")
+		if cmd == nil {
+			t.Errorf("%s view: `R` issued no command", name)
+		}
+		if got.modal.active {
+			t.Errorf("%s view: `R` opened a modal; the README is a full-screen handover", name)
+		}
+	}
+}
+
+// The freeze claim, tested rather than argued: with a modal up, no key reaches
+// the underlying view.
+func TestModalFreezesTheUnderlyingView(t *testing.T) {
+	before := testModel()
+
+	opened, _ := projectKeymap().dispatch("?")(before, "?")
+	if !opened.modal.active {
+		t.Fatal("failed to open the modal")
+	}
+
+	m := tea.Model(opened)
+	for _, key := range []string{"j", "k", "down", "up", "g", "enter", "q", "R", "esc-not-a-key", "x"} {
+		var cmd tea.Cmd
+		m, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)})
+		if cmd != nil {
+			t.Errorf("key %q returned a command through the modal", key)
+		}
+	}
+
+	after, ok := m.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, not a Model", m)
+	}
+	if !after.modal.active {
+		t.Error("the modal closed on a key it does not bind")
+	}
+	if after.targetCursor != before.targetCursor {
+		t.Errorf("targetCursor moved: %d → %d", before.targetCursor, after.targetCursor)
+	}
+	if after.view != before.view {
+		t.Errorf("view changed: %v → %v", before.view, after.view)
+	}
+	if after.selectedProject != before.selectedProject {
+		t.Errorf("selectedProject changed: %d → %d", before.selectedProject, after.selectedProject)
+	}
+	if after.lastRun != before.lastRun {
+		t.Error("lastRun changed behind the modal")
+	}
+}
+
+func TestEscAndQuestionMarkCloseTheModal(t *testing.T) {
+	for _, key := range []string{"esc", "?"} {
+		before := testModel()
+		opened, _ := targetKeymap().dispatch("?")(before, "?")
+
+		h := opened.modal.keys.dispatch(key)
+		if h == nil {
+			t.Fatalf("%q does not close the help overlay", key)
+		}
+
+		closed, cmd := h(opened, key)
+		if closed.modal.active {
+			t.Errorf("%q left the modal active", key)
+		}
+		if cmd != nil {
+			t.Errorf("%q issued a command while closing", key)
+		}
+		if closed.targetCursor != before.targetCursor || closed.view != before.view {
+			t.Errorf("%q disturbed the underlying view", key)
+		}
+	}
+}
+
+// Handlers are individually reachable now, so they guard rather than index
+// blindly into an empty project list.
+func TestBindingsAreSafeWithNoProjects(t *testing.T) {
+	for name, k := range viewKeymaps() {
+		for _, b := range k {
+			for _, key := range b.keys {
+				if key == "q" || key == "ctrl+c" {
+					continue // returns tea.Quit; nothing to guard
+				}
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							t.Errorf("%s view: key %q panicked with no projects: %v", name, key, r)
+						}
+					}()
+					k.dispatch(key)(Model{width: 80, height: 24}, key)
+				}()
+			}
+		}
+	}
+}

--- a/internal/ui/tui/overlay.go
+++ b/internal/ui/tui/overlay.go
@@ -1,0 +1,78 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/ui/tui/styles"
+)
+
+// dimBackground re-renders an already-rendered view so it reads as background
+// behind a modal.
+//
+// Each line is stripped of its own ANSI attributes and re-rendered with a
+// single dim foreground. Dropping the zebra and cursor backgrounds is
+// deliberate: they would compete with the modal for attention, and @UI Patterns
+// asks for "muted colors, or an overlay effect" without mandating a mechanism.
+// The table keeps its shape as a grey ghost.
+func dimBackground(view string) string {
+	lines := strings.Split(view, "\n")
+	for i, line := range lines {
+		lines[i] = styles.Dimmed.Render(ansi.Strip(line))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// splice overwrites fg's lines onto bg starting at column x, row y, and returns
+// the result. The background's line count is never changed: fg lines that would
+// fall past the bottom are dropped rather than extending the view.
+//
+// Widths are measured with lipgloss.Width throughout so ANSI sequences are
+// discounted — the same discipline borderedRow follows.
+func splice(bg, fg string, x, y int) string {
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+
+	bgLines := strings.Split(bg, "\n")
+	fgLines := strings.Split(fg, "\n")
+
+	for i, fgLine := range fgLines {
+		row := y + i
+		if row >= len(bgLines) {
+			break
+		}
+		bgLine := bgLines[row]
+
+		// The background's first x columns, padded out when the line is short.
+		//
+		// TruncateWc/TruncateLeftWc rather than CutWc: in x/ansi v0.10.2 CutWc's
+		// left-cut path is bound to a right-truncating helper and misbehaves on
+		// wide runes.
+		left := ansi.TruncateWc(bgLine, x, "")
+		if pad := x - lipgloss.Width(left); pad > 0 {
+			left += strings.Repeat(" ", pad)
+		}
+		if strings.ContainsRune(left, ansiEscape) {
+			// The cut may have severed the line mid-sequence; close it so the
+			// background's colour cannot bleed into the modal.
+			left += ansiReset
+		}
+
+		right := ansi.TruncateLeftWc(bgLine, x+lipgloss.Width(fgLine), "")
+
+		bgLines[row] = left + fgLine + right
+	}
+
+	return strings.Join(bgLines, "\n")
+}
+
+const (
+	ansiEscape = '\x1b'
+	ansiReset  = "\x1b[0m"
+)

--- a/internal/ui/tui/overlay.go
+++ b/internal/ui/tui/overlay.go
@@ -64,7 +64,20 @@ func splice(bg, fg string, x, y int) string {
 			left += ansiReset
 		}
 
-		right := ansi.TruncateLeftWc(bgLine, x+lipgloss.Width(fgLine), "")
+		cut := x + lipgloss.Width(fgLine)
+		right := ansi.TruncateLeftWc(bgLine, cut, "")
+
+		// The two truncators disagree about a grapheme that straddles the cut
+		// column: TruncateWc drops it, TruncateLeftWc keeps it whole. Left
+		// alone, a double-width background rune under the modal's right edge
+		// makes this one row a column wider than every other, so the border
+		// below it steps sideways. Drop the straddler and pad, matching the
+		// left edge.
+		if want := lipgloss.Width(bgLine) - cut; want > 0 {
+			if over := lipgloss.Width(right) - want; over > 0 {
+				right = strings.Repeat(" ", over) + ansi.TruncateLeftWc(bgLine, cut+over, "")
+			}
+		}
 
 		bgLines[row] = left + fgLine + right
 	}

--- a/internal/ui/tui/overlay_test.go
+++ b/internal/ui/tui/overlay_test.go
@@ -1,0 +1,138 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestSplice(t *testing.T) {
+	tests := []struct {
+		name string
+		bg   string
+		fg   string
+		x, y int
+		want string
+	}{
+		{
+			name: "modal narrower than background",
+			bg:   "..........\n..........\n..........",
+			fg:   "AB\nCD",
+			x:    4,
+			y:    1,
+			want: "..........\n....AB....\n....CD....",
+		},
+		{
+			name: "modal at the left edge",
+			bg:   "..........\n..........",
+			fg:   "XY",
+			x:    0,
+			y:    0,
+			want: "XY........\n..........",
+		},
+		{
+			name: "background line shorter than x is padded",
+			bg:   "ab\n..........",
+			fg:   "MM",
+			x:    5,
+			y:    0,
+			want: "ab   MM\n..........",
+		},
+		{
+			name: "modal wider than the background line",
+			bg:   "..\n..",
+			fg:   "WIDE",
+			x:    0,
+			y:    0,
+			want: "WIDE\n..",
+		},
+		{
+			name: "rows past the bottom are dropped, not appended",
+			bg:   "..........",
+			fg:   "A\nB\nC",
+			x:    2,
+			y:    0,
+			want: "..A.......",
+		},
+		{
+			name: "negative offsets clamp to the origin",
+			bg:   "....\n....",
+			fg:   "Z",
+			x:    -3,
+			y:    -2,
+			want: "Z...\n....",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := splice(tt.bg, tt.fg, tt.x, tt.y); got != tt.want {
+				t.Errorf("splice() =\n%q\nwant\n%q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A CJK background is the case CutWc gets wrong; assert the visible width
+// survives the splice unchanged.
+func TestSpliceWideRuneBackground(t *testing.T) {
+	bg := strings.Repeat("日", 10) // 20 display columns
+	got := splice(bg, "AB", 4, 0)
+
+	if w := lipgloss.Width(got); w != 20 {
+		t.Errorf("spliced width = %d, want 20", w)
+	}
+	if !strings.Contains(got, "AB") {
+		t.Errorf("spliced line lost the foreground: %q", got)
+	}
+}
+
+// The modal must not inherit the dimmed background's colour, and the
+// background either side of the splice must keep its own.
+func TestSpliceANSIBackground(t *testing.T) {
+	// Written as raw SGR rather than via lipgloss: lipgloss suppresses colour
+	// when the test binary's output is not a terminal, which would make this
+	// assertion silently vacuous.
+	bg := "\x1b[31m" + strings.Repeat(".", 20) + "\x1b[0m"
+
+	got := splice(bg, "MM", 8, 0)
+
+	if w := lipgloss.Width(got); w != 20 {
+		t.Errorf("spliced width = %d, want 20", w)
+	}
+	const want = "........MM.........."
+	if plain := ansi.Strip(got); plain != want {
+		t.Errorf("stripped result = %q, want %q", plain, want)
+	}
+	before, _, _ := strings.Cut(got, "MM")
+	if !strings.HasSuffix(before, ansiReset) {
+		t.Errorf("foreground is not insulated from the background's colour: %q", before)
+	}
+}
+
+func TestDimBackgroundStripsAttributesAndPreservesShape(t *testing.T) {
+	style := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("255")).
+		Background(lipgloss.Color("24")).
+		Bold(true)
+	view := style.Render("row one") + "\n" + style.Render("row two")
+
+	got := dimBackground(view)
+
+	if lines := strings.Count(got, "\n"); lines != 1 {
+		t.Errorf("dimBackground changed the line count: got %d newlines, want 1", lines)
+	}
+	for i, line := range strings.Split(got, "\n") {
+		if w := lipgloss.Width(line); w != 7 {
+			t.Errorf("line %d width = %d, want 7", i, w)
+		}
+	}
+	if plain := ansi.Strip(got); plain != "row one\nrow two" {
+		t.Errorf("dimBackground changed the text: %q", plain)
+	}
+	if strings.Contains(got, "\x1b[1m") {
+		t.Error("dimBackground kept the bold attribute from the source view")
+	}
+}

--- a/internal/ui/tui/overlay_test.go
+++ b/internal/ui/tui/overlay_test.go
@@ -77,15 +77,39 @@ func TestSplice(t *testing.T) {
 
 // A CJK background is the case CutWc gets wrong; assert the visible width
 // survives the splice unchanged.
+//
+// Every offset, not just one: at an odd x both edges of the modal land inside a
+// double-width rune, and the two truncators disagree about what to do with a
+// straddler. An even-offset-only test passes while the row silently grows by a
+// column.
 func TestSpliceWideRuneBackground(t *testing.T) {
 	bg := strings.Repeat("日", 10) // 20 display columns
-	got := splice(bg, "AB", 4, 0)
 
-	if w := lipgloss.Width(got); w != 20 {
-		t.Errorf("spliced width = %d, want 20", w)
+	for x := 0; x <= 8; x++ {
+		got := splice(bg, "AB", x, 0)
+
+		if w := lipgloss.Width(got); w != 20 {
+			t.Errorf("x=%d: spliced width = %d, want 20 (%q)", x, w, ansi.Strip(got))
+		}
+		if !strings.Contains(got, "AB") {
+			t.Errorf("x=%d: spliced line lost the foreground: %q", x, got)
+		}
 	}
-	if !strings.Contains(got, "AB") {
-		t.Errorf("spliced line lost the foreground: %q", got)
+}
+
+// The whole point of the width discipline: a modal spliced over a wide-rune
+// background must stay rectangular, or its border steps sideways row by row.
+func TestSpliceKeepsAWideRuneBackgroundRectangular(t *testing.T) {
+	row := strings.Repeat("日", 10)
+	bg := strings.Join([]string{row, row, row, row}, "\n")
+	fg := "┌──┐\n│ab│\n└──┘"
+
+	out := splice(bg, fg, 3, 0)
+
+	for i, line := range strings.Split(out, "\n") {
+		if w := lipgloss.Width(line); w != 20 {
+			t.Errorf("row %d width = %d, want 20: %q", i, w, ansi.Strip(line))
+		}
 	}
 }
 

--- a/internal/ui/tui/styles/styles.go
+++ b/internal/ui/tui/styles/styles.go
@@ -106,10 +106,6 @@ var (
 	ModalBody = lipgloss.NewStyle().
 			Foreground(colorWhite)
 
-	// ModalHintBar is the key hints along the bottom of a modal.
-	ModalHintBar = lipgloss.NewStyle().
-			Foreground(colorDimmed)
-
 	// ModalRule is the horizontal rule separating a modal's header, body and
 	// hint bar.
 	ModalRule = lipgloss.NewStyle().

--- a/internal/ui/tui/styles/styles.go
+++ b/internal/ui/tui/styles/styles.go
@@ -83,4 +83,41 @@ var (
 	FlashError = lipgloss.NewStyle().
 			Foreground(colorRed).
 			Bold(true)
+
+	// ModalBorder is the rounded frame around a modal overlay. Blue, per the
+	// UI Patterns colour conventions, so it separates from the dimmed view
+	// behind it.
+	ModalBorder = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorBlue).
+			Padding(0, 1)
+
+	// ModalTitle is the modal header's left-hand title.
+	ModalTitle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(colorBlue)
+
+	// ModalContext is the modal header's right-aligned context — the view
+	// name, a "Step 1/3" counter, and so on.
+	ModalContext = lipgloss.NewStyle().
+			Foreground(colorDimmed)
+
+	// ModalBody is the modal's content area.
+	ModalBody = lipgloss.NewStyle().
+			Foreground(colorWhite)
+
+	// ModalHintBar is the key hints along the bottom of a modal.
+	ModalHintBar = lipgloss.NewStyle().
+			Foreground(colorDimmed)
+
+	// ModalRule is the horizontal rule separating a modal's header, body and
+	// hint bar.
+	ModalRule = lipgloss.NewStyle().
+			Foreground(colorBorder)
+
+	// Dimmed renders the underlying view while a modal is open: a single
+	// muted foreground, with the row backgrounds dropped so the modal keeps
+	// the eye.
+	Dimmed = lipgloss.NewStyle().
+		Foreground(colorDimmed)
 )


### PR DESCRIPTION
Closes TAE-54.

The architect plan this was built against is the approved comment on
[TAE-54](https://linear.app/taelron/issue/TAE-54/modal-overlay-frame-and-help-overlay-move-readme-off).
Scope is `internal/ui/tui/` and `styles/` only — no app, adapter or domain change.

## ⚠️ `r` no longer runs the selected target

**This removes a working keybinding.** `r` used to run the target under the
cursor. It is now unbound, and **`Enter` is the sole run key**.

No capability is lost — `Enter` has always run the selected target — but anyone
with `r` in their fingers will press it and get nothing.

This is closer to a bug fix than a regression. @UI Patterns reserves `r` for
*refresh* across every Taelron TUI. The collision was live: a user arriving from
FleetDesk and pressing `r` on MkX's target list executed an arbitrary make
target. A convention collision where the wrong key runs a shell command is worse
than a missing binding.

`r` stays unbound rather than being rebound to refresh: the baseline says a list
backed by stable local data omits `r` rather than binding it to a no-op, and
MkX parses Make targets once at startup.

Recorded in @MkX Design Notes. `TestRIsUnbound` asserts it, so a future re-bind
is a deliberate act rather than an accident.

## Also user-visible

- **README moves from `?` to `R`.** The viewer itself is unchanged — still a
  full-screen glamour handover; only the key moved.
- **`?` now opens a help overlay** listing the keys available in the current
  view. `Esc` or `?` closes it.
- **Hint bars change format**, from `<Enter> Drill In` to the baseline's
  `Enter/Drill In`, and change content:
  - projects — `↑↓/Navigate  Enter/Targets  g/Pull  R/Readme  q/Quit  ?/Help`
  - targets — `↑↓/Navigate  Enter/Run  g/Pull  R/Readme  Esc/Back  ?/Help`

## What was built, against the acceptance criteria

| AC | Where |
| -- | -- |
| Reusable modal frame: centred, dimmed background, rounded border, header with optional context, hint bar, ~60% width cap, auto-height, never scrolls | `modal.go`, `overlay.go`, `styles/styles.go` |
| Frame intercepts all key dispatch; underlying view frozen | `model.go` `handleKey` |
| A new modal costs only a content render function, a key handler and a `showModal` call | `modal_help.go` + `helpKeymap()` + one line — the frame is untouched by it |
| `?` opens a context-sensitive help overlay; `Esc`/`?` close | `modal_help.go`, `keymap_views.go` |
| README moves to `R`; `r` stays unbound | `keymap_views.go` |
| Correct at 80×24 and above | `TestHelpFitsAtEightyByTwentyFour` |
| Hint bars match the @UI Patterns formats | `TestHintBarsMatchTheBaselineFormats` |

The design's core idea: **one `[]binding` slice per view is the single source for
the hint bar, the help overlay *and* key dispatch.** The failure mode the issue
names is hint-bar ↔ help drift; carrying the handler on the binding also closes
an axis the issue doesn't name — a key documented in help that no longer works,
or handled but undocumented.

## Notes for review

- **Six commits, one per plan step, each independently buildable.** Nothing in
  `make verify` protects any of this; the new `internal/ui/tui` tests are the
  only net and they ship in the same PR, so separable commits are what makes a
  bisect possible.
- **Plan steps 2 and 3 are swapped in commit order.** `modalState` carries a
  `keymap` field, so the type has to exist before the modal frame commit can
  build on its own. No change to the final state.
- **A seventh commit fixes two defects the in-session review found** — `splice`
  growing a row by a column when a double-width rune straddled the modal's right
  edge, and `buildModalBox` letting an over-wide header word-wrap instead of
  truncating (reachable at 80 columns with a deeply nested project path). Both
  were reproduced before fixing and re-checked by reverting the fix and watching
  the new test fail.
- **`styles.ModalHintBar` is the one plan line-item not delivered.** The modal's
  hint bar renders through the shared `HintKey`/`HintAction` styling like every
  other hint bar, so a modal-specific style would have been dead code.
- Three soft deviations are already recorded in @MkX Design Notes and were
  approved at plan time: `q/Quit` in the root hint bar where the patterns put
  `Esc/Back` (the project list is the root; `Esc` has no parent), the help
  modal's `Esc/Close  ?/Close` bar instead of `Enter/Confirm  Esc/Cancel` (info
  content has nothing to confirm), and the `r` unbinding.
- `docs/screenshot-*.png` still show the old `<key> Action` hint bar and are now
  stale. Regenerating them is **TAE-56**, deliberately not in this PR.

## Verification handoff

Run top to bottom from the repo root. `verify-tui` is new; everything else
already existed.

| # | command | purpose | expected |
| -- | -- | -- | -- |
| 1 | `make build` | compiles after the `x/ansi` promotion to a direct dependency | builds; `mkx` written to the repo root |
| 2 | `make tidy-check` | `x/ansi` moved to the direct require block cleanly | no diff in `go.mod`/`go.sum` |
| 3 | `make test` | full suite, including the new `internal/ui/tui` tests | all pass |
| 4 | `make verify-tui` | **new** — the TUI tests by name, so each assertion is visible rather than folded into a package-level `ok` | 38 top-level `--- PASS` lines, no FAIL |
| 5 | `make verify` | the characterization golden is untouched | PASS **with no rebaseline**. This is the evidence the change is `ui/tui`-only — if discovery behaviour had moved, this fails |
| 6 | `make verify-parser` | parser table tests unaffected | all pass |
| 7 | `make verify-guards` | the golden guards still bite | the sabotaged copy fails as designed |
| 8 | `make run` | launches the TUI against `testdata/fixtures/` for the visual pass below | TUI opens on the projects list |

### Visual sequence under `make run`

The fixtures give four projects — `alpha`, `beta`, `beta/nested`,
`deep/level2/level3` — with READMEs on the first three and none on the fourth.

1. Projects list. Hint bar reads `↑↓/Navigate  Enter/Targets  g/Pull  R/Readme  q/Quit  ?/Help` — slashes, not angle brackets.
2. Press `?`. A centred box with a **blue rounded border** appears. The project table is still visible behind it, uniformly dimmed, with the zebra and cursor backgrounds gone.
3. **With help open, press `j`, `k`, `g`, `Enter`, `x`. Nothing moves** — no cursor movement, no pull, no drill-in, no flash. The modal stays up.
4. Press `Esc`. Help closes; the cursor is exactly where it was.
5. Press `?` then `?` again. Opens and closes.
6. Press `R` on `alpha`. Full-screen glamour README; `Enter` returns to the TUI.
7. Move to `deep/level2/level3`, press `R`. Flash reads `No README.md found`.
8. Press `?`. Confirm it does **not** open the README.
9. `Enter` into `alpha`. Hint bar reads `↑↓/Navigate  Enter/Run  g/Pull  R/Readme  Esc/Back  ?/Help`.
10. Press `?`. Help lists the *target* view's keys, including `q — Quit mkx` which is not in the bar, and **no `r` entry**.
11. **Close help, press `r`. Nothing happens.**
12. Press `Enter`. The target runs and hands the terminal over as before.
13. Resize to 80×24 and press `?`. The modal fits with no wrapping or clipping.

Steps 3 and 11 are the load-bearing ones. Step 13 is **aesthetic only** — terminal
size is your environment, not the build's; the programmatic check is
`TestHelpFitsAtEightyByTwentyFour` in target 4, which renders at 80×24 and asserts
the line-width and line-count bounds *and* that nothing truncated. If step 13
looks wrong while target 4 passes, that is a bug in the test's assumptions and
worth reporting.

Steps 6 and 7 are the only ones not already exercised mechanically here — the
README handover leaves the alt screen, which a headless capture cannot model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
