### PR TITLE
Target filtering

### DIFF
--- a/internal/ui/tui/filter.go
+++ b/internal/ui/tui/filter.go
@@ -1,0 +1,88 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+)
+
+// filtered returns the items whose visible fields, concatenated and lowercased,
+// contain text. Matching is substring, not fuzzy, per @UI Patterns.
+//
+// The extractor closure is what keeps this one helper rather than a
+// filteredTargets() per view: a caller names the fields its rows actually show,
+// and nothing here knows what a Target is.
+func filtered[T any](items []T, text string, fields func(T) []string) []T {
+	if text == "" {
+		return items
+	}
+
+	needle := strings.ToLower(text)
+	out := make([]T, 0, len(items))
+	for _, item := range items {
+		if strings.Contains(strings.ToLower(strings.Join(fields(item), " ")), needle) {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// filterState is filter mode's whole state. Its zero value is "no filter in
+// effect", so a Model needs no wiring to start unfiltered.
+//
+// active and text are independent: Enter closes the mode while keeping the
+// text, which is the state that keeps the list filtered and the bar on screen.
+type filterState struct {
+	active bool
+	text   string
+}
+
+// The mutators live on Model, not on filterState, because the "cursor resets on
+// every text change" invariant spans two structs — m.filter.text and
+// m.targetCursor. setFilterText is the single place that enforces it, and every
+// other mutator routes through it.
+
+// activateFilter enters filter mode from scratch: empty text, cursor at the
+// top. `/` never resumes a previous filter.
+func (m Model) activateFilter() Model {
+	m.filter.active = true
+	return m.setFilterText("")
+}
+
+// setFilterText is the one place filter text changes, and therefore the one
+// place the cursor resets.
+func (m Model) setFilterText(s string) Model {
+	m.filter.text = s
+	m.targetCursor = 0
+	return m
+}
+
+func (m Model) appendFilterRunes(rs []rune) Model {
+	return m.setFilterText(m.filter.text + string(rs))
+}
+
+// backspaceFilter deletes the last rune, not the last byte: a multi-byte rune
+// would otherwise be cut into invalid UTF-8. On empty text it is a no-op.
+func (m Model) backspaceFilter() Model {
+	rs := []rune(m.filter.text)
+	if len(rs) == 0 {
+		return m
+	}
+	return m.setFilterText(string(rs[:len(rs)-1]))
+}
+
+// clearFilter drops both the mode and the text — Esc's effect in either of the
+// two states where a filter is in effect.
+func (m Model) clearFilter() Model {
+	m.filter.active = false
+	return m.setFilterText("")
+}
+
+// filteredTargets is the single computation point for the visible target list.
+// The renderer, the cursor bound check and the enter handler all call it, so no
+// call site branches on "is a filter active" and no derived field can go stale.
+func (m Model) filteredTargets(proj domain.Project) []domain.Target {
+	return filtered(proj.Targets, m.filter.text, func(t domain.Target) []string {
+		return []string{t.Name, t.Description}
+	})
+}

--- a/internal/ui/tui/filter_test.go
+++ b/internal/ui/tui/filter_test.go
@@ -1,0 +1,490 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/app"
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+)
+
+// filterModel is testModel's project with a third target whose name does not
+// match but whose description does — the case that proves matching reaches
+// past Name.
+func filterModel() Model {
+	m := testModel()
+	m.projects[0].Targets = []domain.Target{
+		{Name: "build", Description: "Compile the binary"},
+		{Name: "test", Description: "Run tests"},
+		{Name: "verify", Description: "Check discovery against the golden"},
+	}
+	m.targetCursor = 0
+	return m
+}
+
+func names(ts []domain.Target) []string {
+	out := make([]string, 0, len(ts))
+	for _, t := range ts {
+		out = append(out, t.Name)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------- matching
+
+func TestFilteredMatching(t *testing.T) {
+	targets := filterModel().projects[0].Targets
+	fields := func(tg domain.Target) []string { return []string{tg.Name, tg.Description} }
+
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{name: "name substring", text: "ver", want: []string{"verify"}},
+		{name: "description substring, name does not match", text: "golden", want: []string{"verify"}},
+		{name: "lowercase needle against mixed-case field", text: "compile", want: []string{"build"}},
+		{name: "uppercase needle", text: "COMPILE", want: []string{"build"}},
+		{name: "empty text returns everything", text: "", want: []string{"build", "test", "verify"}},
+		{name: "no match returns nothing", text: "zzz", want: nil},
+		{name: "matches several", text: "e", want: []string{"build", "test", "verify"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := names(filtered(targets, tt.text, fields))
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Errorf("filtered(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+// Substring, not fuzzy: the characters of "bld" appear in "build" in order,
+// and must not match.
+func TestFilteredIsSubstringNotFuzzy(t *testing.T) {
+	targets := filterModel().projects[0].Targets
+	got := filtered(targets, "bld", func(tg domain.Target) []string {
+		return []string{tg.Name, tg.Description}
+	})
+	if len(got) != 0 {
+		t.Errorf("filtered(%q) = %v, want no matches — matching is substring, not fuzzy", "bld", names(got))
+	}
+}
+
+// The helper is generic over its item type; the field extractor is what a
+// caller supplies. Asserted so a future refactor to a concrete
+// filteredTargets() shows up here.
+func TestFilteredIsGenericOverTheItemType(t *testing.T) {
+	got := filtered([]string{"alpha", "beta"}, "et", func(s string) []string { return []string{s} })
+	if len(got) != 1 || got[0] != "beta" {
+		t.Errorf("filtered over []string = %v, want [beta]", got)
+	}
+}
+
+// ------------------------------------------------------- the state machine
+
+func TestSlashActivatesFilterMode(t *testing.T) {
+	m := filterModel()
+	m.targetCursor = 2
+
+	got, cmd := targetKeymap().dispatch("/")(m, "/")
+
+	if !got.filter.active {
+		t.Error("`/` did not activate filter mode")
+	}
+	if got.filter.text != "" {
+		t.Errorf("`/` left filter text %q, want empty", got.filter.text)
+	}
+	if got.targetCursor != 0 {
+		t.Errorf("`/` left the cursor at %d, want 0", got.targetCursor)
+	}
+	if cmd != nil {
+		t.Error("`/` issued a command")
+	}
+}
+
+// `/` starts from scratch rather than resuming the previous filter.
+func TestSlashResetsAPreviousFilter(t *testing.T) {
+	m := filterModel()
+	m.filter = filterState{active: false, text: "ver"}
+
+	got, _ := targetKeymap().dispatch("/")(m, "/")
+
+	if got.filter.text != "" {
+		t.Errorf("`/` resumed the previous filter (%q), want a fresh empty one", got.filter.text)
+	}
+}
+
+func TestBackspaceDeletesOneRune(t *testing.T) {
+	m := filterModel()
+	m.filter = filterState{active: true, text: "vér"}
+
+	got := m.backspaceFilter()
+
+	if got.filter.text != "vé" {
+		t.Errorf("backspace = %q, want %q — deletion is rune-aware, not byte-aware", got.filter.text, "vé")
+	}
+}
+
+func TestBackspaceOnEmptyTextIsANoOp(t *testing.T) {
+	m := filterModel()
+	m.filter = filterState{active: true, text: ""}
+
+	if got := m.backspaceFilter(); got.filter.text != "" {
+		t.Errorf("backspace on empty text = %q, want empty", got.filter.text)
+	}
+}
+
+// The invariant that spans two structs: every text change resets the cursor.
+func TestCursorResetsOnEveryTextChange(t *testing.T) {
+	tests := []struct {
+		name   string
+		change func(Model) Model
+	}{
+		{name: "append", change: func(m Model) Model { return m.appendFilterRunes([]rune("v")) }},
+		{name: "backspace", change: func(m Model) Model { return m.backspaceFilter() }},
+		{name: "clear", change: func(m Model) Model { return m.clearFilter() }},
+		{name: "activate", change: func(m Model) Model { return m.activateFilter() }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := filterModel()
+			m.filter = filterState{active: true, text: "te"}
+			m.targetCursor = 2
+
+			if got := tt.change(m); got.targetCursor != 0 {
+				t.Errorf("%s left the cursor at %d, want 0", tt.name, got.targetCursor)
+			}
+		})
+	}
+}
+
+// The three Esc states, which is the whole reason Esc is not a single branch.
+func TestEscByFilterState(t *testing.T) {
+	tests := []struct {
+		name       string
+		start      filterState
+		wantView   view
+		wantFilter filterState
+	}{
+		{
+			name:       "filter mode active: clear the text, close the mode, stay",
+			start:      filterState{active: true, text: "ver"},
+			wantView:   viewTargets,
+			wantFilter: filterState{},
+		},
+		{
+			name:       "mode closed but text still set: clear the text, stay",
+			start:      filterState{active: false, text: "ver"},
+			wantView:   viewTargets,
+			wantFilter: filterState{},
+		},
+		{
+			name:       "active with empty text: close the mode, stay",
+			start:      filterState{active: true, text: ""},
+			wantView:   viewTargets,
+			wantFilter: filterState{},
+		},
+		{
+			name:       "no filter in effect: back to the project list",
+			start:      filterState{},
+			wantView:   viewProjects,
+			wantFilter: filterState{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := filterModel()
+			m.filter = tt.start
+
+			got, cmd := targetKeymap().dispatch("esc")(m, "esc")
+
+			if got.view != tt.wantView {
+				t.Errorf("view = %v, want %v", got.view, tt.wantView)
+			}
+			if got.filter != tt.wantFilter {
+				t.Errorf("filter = %+v, want %+v", got.filter, tt.wantFilter)
+			}
+			if cmd != nil {
+				t.Error("esc issued a command")
+			}
+		})
+	}
+}
+
+func TestEnterWhileFilteringClosesTheModeAndRunsNothing(t *testing.T) {
+	m := filterModel()
+	m.filter = filterState{active: true, text: "ver"}
+
+	got, cmd := targetKeymap().dispatch("enter")(m, "enter")
+
+	if cmd != nil {
+		t.Error("enter ran a target while filter mode was active; it is the mode exit")
+	}
+	if got.filter.active {
+		t.Error("enter left filter mode active")
+	}
+	if got.filter.text != "ver" {
+		t.Errorf("enter cleared the filter text (%q); the matched results stay visible", got.filter.text)
+	}
+}
+
+// recordingRunner captures the target name the app was asked to build a
+// command for. Nothing is executed: tea.Exec only wraps the command in a
+// message, and the process would run in the Bubble Tea runtime, not here.
+type recordingRunner struct{ ran *string }
+
+func (recordingRunner) Discover(context.Context, string) ([]domain.Target, error) {
+	return nil, nil
+}
+
+func (r recordingRunner) TargetCommand(_ context.Context, dir, name string) domain.Command {
+	*r.ran = name
+	return domain.Command{Argv: []string{"make", name}, WorkDir: dir}
+}
+
+// The bug this issue would otherwise ship: with a filter in effect, cursor 0 is
+// the first *match*, not proj.Targets[0].
+func TestEnterRunsTheFilteredTargetNotTheUnfilteredOne(t *testing.T) {
+	var ran string
+	m := filterModel()
+	m.app = app.New(fakeScanner{}, recordingRunner{ran: &ran})
+	m.filter = filterState{active: false, text: "ver"} // matches only "verify"
+	m.targetCursor = 0
+
+	_, cmd := targetKeymap().dispatch("enter")(m, "enter")
+	if cmd == nil {
+		t.Fatal("enter issued no command with a filter in effect")
+	}
+	if msg := cmd(); msg == nil {
+		t.Fatal("the command produced no message")
+	}
+
+	if ran != "verify" {
+		t.Errorf("enter ran %q, want %q — the cursor indexes the filtered slice, not proj.Targets", ran, "verify")
+	}
+
+	// A cursor past the end of the filtered slice must not run anything.
+	ran = ""
+	m.targetCursor = 1
+	if _, cmd := targetKeymap().dispatch("enter")(m, "enter"); cmd != nil {
+		t.Errorf("enter ran %q with the cursor past the last match", ran)
+	}
+}
+
+func TestDownIsBoundAgainstTheFilteredLength(t *testing.T) {
+	m := filterModel()
+	m.filter = filterState{active: false, text: "ver"} // one match
+	m.targetCursor = 0
+
+	got, _ := targetKeymap().dispatch("down")(m, "down")
+
+	if got.targetCursor != 0 {
+		t.Errorf("cursor walked to %d past the only match; down must bound against the filtered length", got.targetCursor)
+	}
+
+	// Unfiltered, the same key still moves.
+	m.filter = filterState{}
+	if got, _ := targetKeymap().dispatch("down")(m, "down"); got.targetCursor != 1 {
+		t.Errorf("unfiltered cursor = %d, want 1", got.targetCursor)
+	}
+}
+
+func TestFilterIsZeroedOnEnteringTheTargetView(t *testing.T) {
+	m := filterModel()
+	m.view = viewProjects
+	m.filter = filterState{active: true, text: "ver"}
+
+	got, _ := projectKeymap().dispatch("enter")(m, "enter")
+
+	if got.filter != (filterState{}) {
+		t.Errorf("entering the target view kept filter %+v, want the zero value", got.filter)
+	}
+}
+
+// --------------------------------------------------------- dispatch tiers
+
+// key builds the tea.KeyMsg the terminal actually produces, which is what the
+// capture switches on — msg.Type, not msg.String().
+func runeKey(s string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+// Tier 1 still precedes tier 2: with a modal up, a rune does not reach the
+// filter even when filter mode is active.
+func TestModalOutranksFilterCapture(t *testing.T) {
+	m := filterModel()
+	m.filter = filterState{active: true, text: ""}
+	opened, _ := targetKeymap().dispatch("?")(m, "?")
+	if !opened.modal.active {
+		t.Fatal("failed to open the modal")
+	}
+
+	after, _ := opened.Update(runeKey("g"))
+	got, ok := after.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, not a Model", after)
+	}
+
+	if got.filter.text != "" {
+		t.Errorf("a rune typed into the filter (%q) through an open modal", got.filter.text)
+	}
+	if !got.modal.active {
+		t.Error("the modal closed on a key it does not bind")
+	}
+}
+
+// The rune-capture consequence, asserted rather than assumed: while filtering,
+// `g` types instead of pulling.
+func TestPrintableKeysTypeIntoTheFilterRatherThanFiring(t *testing.T) {
+	m := filterModel()
+	m.filter = filterState{active: true, text: ""}
+
+	for _, r := range []string{"g", "R", "q", "j", "k", "?", "/"} {
+		after, cmd := m.Update(runeKey(r))
+		got, ok := after.(Model)
+		if !ok {
+			t.Fatalf("Update returned %T, not a Model", after)
+		}
+		if got.filter.text != r {
+			t.Errorf("key %q: filter text = %q, want %q", r, got.filter.text, r)
+		}
+		if cmd != nil {
+			t.Errorf("key %q: fired its binding while filtering", r)
+		}
+		if got.modal.active {
+			t.Errorf("key %q: opened a modal while filtering", r)
+		}
+	}
+}
+
+func TestFilterCaptureAppendsSpaceButNotAltRunes(t *testing.T) {
+	m := filterModel()
+	m.filter = filterState{active: true, text: "run"}
+
+	// Space arrives as KeySpace, not KeyRunes: descriptions contain spaces, so
+	// a bare KeyRunes test would silently drop them.
+	after, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
+	got := after.(Model)
+	if got.filter.text != "run " {
+		t.Errorf("space gave %q, want %q", got.filter.text, "run ")
+	}
+
+	// alt+g is not text. Key.String() would report "alt+g", which a
+	// string-length test would have accepted.
+	after, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("g"), Alt: true})
+	got = after.(Model)
+	if got.filter.text != "run" {
+		t.Errorf("alt+g gave %q, want the text unchanged at %q", got.filter.text, "run")
+	}
+}
+
+func TestBackspaceReachesTheFilterThroughUpdate(t *testing.T) {
+	m := filterModel()
+	m.filter = filterState{active: true, text: "ver"}
+
+	after, cmd := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	got := after.(Model)
+
+	if got.filter.text != "ve" {
+		t.Errorf("backspace gave %q, want %q", got.filter.text, "ve")
+	}
+	if cmd != nil {
+		t.Error("backspace issued a command")
+	}
+}
+
+// Non-printable keys fall through tier 2 to the view's bindings and keep
+// working while filtering.
+func TestNavigationAndExitKeysStillDispatchWhileFiltering(t *testing.T) {
+	base := filterModel()
+	base.filter = filterState{active: true, text: ""}
+
+	t.Run("down navigates", func(t *testing.T) {
+		after, _ := base.Update(tea.KeyMsg{Type: tea.KeyDown})
+		if got := after.(Model); got.targetCursor != 1 {
+			t.Errorf("down while filtering left the cursor at %d, want 1", got.targetCursor)
+		}
+	})
+
+	t.Run("up navigates", func(t *testing.T) {
+		m := base
+		m.targetCursor = 1
+		after, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+		if got := after.(Model); got.targetCursor != 0 {
+			t.Errorf("up while filtering left the cursor at %d, want 0", got.targetCursor)
+		}
+	})
+
+	t.Run("enter closes filter mode", func(t *testing.T) {
+		after, cmd := base.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		if got := after.(Model); got.filter.active {
+			t.Error("enter while filtering left the mode active")
+		}
+		if cmd != nil {
+			t.Error("enter while filtering issued a command")
+		}
+	})
+
+	t.Run("esc clears", func(t *testing.T) {
+		m := base
+		m.filter = filterState{active: true, text: "ver"}
+		after, _ := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+		got := after.(Model)
+		if got.filter != (filterState{}) {
+			t.Errorf("esc while filtering left filter %+v", got.filter)
+		}
+		if got.view != viewTargets {
+			t.Error("esc left the view instead of clearing the filter first")
+		}
+	})
+
+	t.Run("ctrl+c quits", func(t *testing.T) {
+		_, cmd := base.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+		if cmd == nil {
+			t.Error("ctrl+c did not quit while filtering")
+		}
+	})
+}
+
+// ----------------------------------------------------------- projections
+
+// The check that this issue did not undo TAE-54: `/` is declared once, and the
+// hint bar and help overlay pick it up without a second list.
+func TestSlashProjectsIntoTheHintBarAndHelp(t *testing.T) {
+	k := targetKeymap()
+
+	if !strings.Contains(strings.Join(k.helpRows(), "\n"), "Filter by name or description") {
+		t.Error("the `/` binding is missing from the target view's help rows")
+	}
+
+	var slashBindings int
+	for _, b := range k {
+		if b.display == "/" {
+			slashBindings++
+		}
+	}
+	if slashBindings != 1 {
+		t.Errorf("the target keymap declares `/` %d times, want exactly 1", slashBindings)
+	}
+}
+
+// Out of scope, asserted so it stays that way: the projects view has no filter.
+func TestProjectsViewHasNoFilter(t *testing.T) {
+	k := projectKeymap()
+
+	if k.dispatch("/") != nil {
+		t.Error("`/` is bound in the projects view; filtering the project list is out of scope")
+	}
+	for _, b := range k {
+		if b.display == "/" || b.label == "Search" {
+			t.Errorf("the projects keymap carries a Search binding (%q)", b.label)
+		}
+	}
+}

--- a/internal/ui/tui/keymap_views.go
+++ b/internal/ui/tui/keymap_views.go
@@ -36,6 +36,8 @@ func projectKeymap() keymap {
 				if len(m.projects) > 0 {
 					m.selectedProject = m.projectCursor
 					m.targetCursor = 0
+					// A filter never survives leaving the view it filtered.
+					m.filter = filterState{}
 					m.view = viewTargets
 				}
 				return m, nil
@@ -83,19 +85,41 @@ func targetKeymap() keymap {
 			help: "Move the cursor down", inBar: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				proj, ok := m.currentProject()
-				if ok && m.targetCursor < len(proj.Targets)-1 {
+				// Bound against the filtered length, not the full list:
+				// otherwise the cursor walks past the last visible row.
+				if ok && m.targetCursor < len(m.filteredTargets(proj))-1 {
 					m.targetCursor++
 				}
 				return m, nil
 			}},
+		{keys: []string{"/"}, display: "/", label: "Search",
+			// Kept short: the help overlay's inner width is ~44 columns at
+			// 80×24, and a row that truncates fails the suite.
+			help: "Filter by name or description", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				return m.activateFilter(), nil
+			}},
 		{keys: []string{"enter"}, display: "Enter", label: "Run",
 			help: "Run the selected target", inBar: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
-				proj, ok := m.currentProject()
-				if !ok || len(proj.Targets) == 0 {
+				// While filtering, Enter is the mode exit: it keeps the matched
+				// results visible and runs nothing. A second Enter runs.
+				if m.filter.active {
+					m.filter.active = false
 					return m, nil
 				}
-				return m, m.runTarget(proj, proj.Targets[m.targetCursor])
+				proj, ok := m.currentProject()
+				if !ok {
+					return m, nil
+				}
+				// Resolved through the filtered slice — running
+				// proj.Targets[cursor] would run the wrong target whenever a
+				// filter is in effect.
+				targets := m.filteredTargets(proj)
+				if m.targetCursor < 0 || m.targetCursor >= len(targets) {
+					return m, nil
+				}
+				return m, m.runTarget(proj, targets[m.targetCursor])
 			}},
 		{keys: []string{"g"}, display: "g", label: "Pull",
 			help: "Git pull and re-read targets", inBar: true,
@@ -117,6 +141,14 @@ func targetKeymap() keymap {
 		{keys: []string{"esc"}, display: "Esc", label: "Back",
 			help: "Back to the project list", inBar: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				// Esc clears whenever there is anything to clear — filter mode
+				// active, or mode closed by Enter with the text still in
+				// effect. Only with no filter at all does it leave the view.
+				// That keeps "Esc clears the filter, then exits" true in every
+				// state, and leaves no filter that Esc cannot reach.
+				if m.filter.active || m.filter.text != "" {
+					return m.clearFilter(), nil
+				}
 				m.view = viewProjects
 				m.lastRun = nil
 				return m, nil

--- a/internal/ui/tui/model.go
+++ b/internal/ui/tui/model.go
@@ -47,6 +47,9 @@ type Model struct {
 	targetCursor    int
 	selectedProject int
 
+	// filter mode over the target list; the zero value is no filter
+	filter filterState
+
 	// last run
 	lastRun *runResult
 
@@ -125,6 +128,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // makes the modal interception below total: no key can reach a view's bindings
 // while a modal is up, because the view keymap is only consulted past the early
 // return.
+//
+// Dispatch is three tiers, strictly ordered:
+//
+//  1. the modal's keymap — absolute, an unbound key is a no-op
+//  2. filter mode's rune capture, when filter mode is active
+//  3. the view's keymap — the registry path
+//
+// Tier 2 sits after tier 1's unconditional return, so with a modal up the
+// filter never sees a key. When filter mode is inactive it is a no-op and the
+// path is what it was before filtering existed.
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
@@ -139,6 +152,30 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Below the interception, so keys pressed inside a modal do not clear a
 	// flash that is hidden behind it anyway.
 	m.flash = ""
+
+	// Rune capture is not expressible as a binding: a binding.keys is a finite
+	// list, and capture claims the whole rune space — including keys this same
+	// keymap binds (g, R, q, ?, /). So it is its own tier, and it enumerates
+	// nothing rather than being a second key list.
+	//
+	// The consequence is deliberate: while filtering, printable keys type
+	// instead of firing. A filter for `generate` is untypeable otherwise.
+	// Arrows, Enter, Esc and Ctrl+C fall through to tier 3 and still dispatch.
+	//
+	// Switching on msg.Type rather than msg.String(): Key.String() prefixes
+	// "alt+" for alt-modified runes, and a space arrives as KeySpace, not
+	// KeyRunes. A string test would take alt+g as text; a bare KeyRunes test
+	// would silently drop spaces, which target descriptions are full of.
+	if m.filter.active {
+		switch {
+		case msg.Type == tea.KeyRunes && !msg.Alt:
+			return m.appendFilterRunes(msg.Runes), nil
+		case msg.Type == tea.KeySpace && !msg.Alt:
+			return m.appendFilterRunes([]rune{' '}), nil
+		case msg.Type == tea.KeyBackspace:
+			return m.backspaceFilter(), nil
+		}
+	}
 
 	if h := m.viewKeymap().dispatch(key); h != nil {
 		return h(m, key)
@@ -360,6 +397,10 @@ func (m Model) renderProjectList() string {
 
 func (m Model) renderTargetList() string {
 	proj := m.projects[m.selectedProject]
+	// Computed once: the header count, the column widths, the viewport window
+	// and the row loop all read this, so nothing below branches on whether a
+	// filter is in effect.
+	targets := m.filteredTargets(proj)
 	w := m.width
 	if w < 20 {
 		w = 80
@@ -368,14 +409,28 @@ func (m Model) renderTargetList() string {
 	iw := w - 2
 
 	// header
-	s := m.renderHeader(proj.Name, m.targetCursor+1, len(proj.Targets)) + "\n"
+	s := m.renderHeader(proj.Name, m.targetCursor+1, len(targets)) + "\n"
 	s += styles.Border.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
 
-	if len(proj.Targets) == 0 {
+	// The filter bar renders on the text, not on the mode: after Enter closes
+	// filter mode the list stays filtered, and this bar is what explains why.
+	// It is part of the view, below the top border, never an overlay.
+	filterBar := m.filter.text != ""
+	if filterBar {
+		s += borderedRow("  Filter: "+m.filter.text, iw, styles.FilterBar) + "\n"
+		s += styles.Border.Render("├"+strings.Repeat("─", iw)+"┤") + "\n"
+	}
+
+	switch {
+	case len(proj.Targets) == 0:
 		s += borderedRow("  No targets found.", iw, styles.NormalRow) + "\n"
-	} else {
+	case len(targets) == 0:
+		// A filter matching nothing gets an empty state naming a real key in
+		// this view, not a blank content area.
+		s += borderedRow("  No targets match. Press Esc to clear the filter.", iw, styles.NormalRow) + "\n"
+	default:
 		nameCol := len("TARGET")
-		for _, t := range proj.Targets {
+		for _, t := range targets {
 			if len(t.Name) > nameCol {
 				nameCol = len(t.Name)
 			}
@@ -388,6 +443,11 @@ func (m Model) renderTargetList() string {
 		s += styles.Border.Render("├"+strings.Repeat("─", iw)+"┤") + "\n"
 
 		maxVisible := m.height - 8
+		if filterBar {
+			// The bar and its separator are two more lines; without this the
+			// content area overflows its frame by two rows.
+			maxVisible -= 2
+		}
 		if maxVisible < 1 {
 			maxVisible = 1
 		}
@@ -397,12 +457,12 @@ func (m Model) renderTargetList() string {
 			offset = m.targetCursor - maxVisible + 1
 		}
 		end := offset + maxVisible
-		if end > len(proj.Targets) {
-			end = len(proj.Targets)
+		if end > len(targets) {
+			end = len(targets)
 		}
 
 		for i := offset; i < end; i++ {
-			t := proj.Targets[i]
+			t := targets[i]
 			cur := "   "
 			if i == m.targetCursor {
 				cur = " ▸ "

--- a/internal/ui/tui/model_test.go
+++ b/internal/ui/tui/model_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -99,7 +100,7 @@ func TestHintBarsMatchTheBaselineFormats(t *testing.T) {
 		{
 			name: "targets",
 			k:    targetKeymap(),
-			want: "↑↓/Navigate  Enter/Run  g/Pull  R/Readme  Esc/Back  ?/Help",
+			want: "↑↓/Navigate  //Search  Enter/Run  g/Pull  R/Readme  Esc/Back  ?/Help",
 		},
 	}
 
@@ -225,6 +226,113 @@ func TestEscAndQuestionMarkCloseTheModal(t *testing.T) {
 		if closed.targetCursor != before.targetCursor || closed.view != before.view {
 			t.Errorf("%q disturbed the underlying view", key)
 		}
+	}
+}
+
+// ------------------------------------------------------------ filter render
+
+func TestFilterBarRendersOnTheTextNotTheMode(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter filterState
+		want   bool
+	}{
+		{name: "mode active, text set", filter: filterState{active: true, text: "bui"}, want: true},
+		// The state Enter produces: the list is still filtered, so the bar is
+		// what explains why rows are missing.
+		{name: "mode closed, text set", filter: filterState{active: false, text: "bui"}, want: true},
+		{name: "mode active, text empty", filter: filterState{active: true, text: ""}, want: false},
+		{name: "no filter", filter: filterState{}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := filterModel()
+			m.filter = tt.filter
+			rendered := ansi.Strip(m.renderTargetList())
+
+			if got := strings.Contains(rendered, "Filter:"); got != tt.want {
+				t.Errorf("filter bar rendered = %v, want %v", got, tt.want)
+			}
+			if tt.want && !strings.Contains(rendered, "Filter: "+tt.filter.text) {
+				t.Errorf("the bar does not carry the filter text %q", tt.filter.text)
+			}
+		})
+	}
+}
+
+func TestNoMatchShowsItsOwnEmptyState(t *testing.T) {
+	m := filterModel()
+	m.filter = filterState{active: true, text: "zzz"}
+	got := ansi.Strip(m.renderTargetList())
+
+	if !strings.Contains(got, "No targets match. Press Esc to clear the filter.") {
+		t.Error("a filter matching nothing did not show the empty state")
+	}
+	if strings.Contains(got, "No targets found.") {
+		t.Error("a filter matching nothing showed the no-targets-at-all state")
+	}
+
+	// The other empty state is still the one a project with no targets gets.
+	empty := filterModel()
+	empty.projects[0].Targets = nil
+	if !strings.Contains(ansi.Strip(empty.renderTargetList()), "No targets found.") {
+		t.Error("a project with no targets lost its empty state")
+	}
+}
+
+// The maxVisible correction, as a tested claim rather than an asserted one: the
+// filter bar and its separator cost two rows, so the frame keeps its height.
+func TestFilterBarDoesNotChangeTheRenderedHeight(t *testing.T) {
+	// Enough targets to overflow the viewport at every height under test, so
+	// the row loop — not the padding — is what has to give up the two lines.
+	many := make([]domain.Target, 40)
+	for i := range many {
+		many[i] = domain.Target{Name: fmt.Sprintf("target-%02d", i), Description: "filterable"}
+	}
+
+	// 10 is the lowest height at which the row budget can absorb the bar; see
+	// TestFilterBarBelowTheChromeFloor for what happens under it.
+	for _, height := range []int{10, 11, 12, 24, 40} {
+		unfiltered := filterModel()
+		unfiltered.projects[0].Targets = many
+		unfiltered.height = height
+
+		bar := unfiltered
+		bar.filter = filterState{active: true, text: "filterable"} // matches all 40
+
+		want := strings.Count(unfiltered.renderTargetList(), "\n")
+		got := strings.Count(bar.renderTargetList(), "\n")
+		if got != want {
+			t.Errorf("height %d: %d lines with the filter bar, %d without", height, got, want)
+		}
+	}
+}
+
+// The boundary the -2 correction cannot cross, pinned rather than left to be
+// rediscovered: below height 10 the row budget has already hit its floor of one
+// row, so the bar's two lines are pure addition and the frame grows.
+//
+// The chrome is irreducible — header, top border, bar, separator, column
+// header, separator, bottom border, hint bar is eight lines before any content
+// — so the only way to hold the height would be to drop the bar, which the
+// acceptance criteria explicitly require to render whenever the filter text is
+// set. The unfiltered view has the same floor one notch lower. Recorded here so
+// a future change to either number is a deliberate act.
+func TestFilterBarBelowTheChromeFloor(t *testing.T) {
+	m := filterModel()
+	m.height = 8
+	m.filter = filterState{active: true, text: "e"} // matches every target
+
+	unfiltered := m
+	unfiltered.filter = filterState{}
+
+	got := strings.Count(m.renderTargetList(), "\n")
+	want := strings.Count(unfiltered.renderTargetList(), "\n")
+
+	if got-want != 2 {
+		t.Errorf("height 8: %d lines with the bar, %d without (delta %d); the documented floor delta is 2",
+			got, want, got-want)
 	}
 }
 

--- a/internal/ui/tui/styles/styles.go
+++ b/internal/ui/tui/styles/styles.go
@@ -60,6 +60,11 @@ var (
 	Border = lipgloss.NewStyle().
 		Foreground(colorBorder)
 
+	// FilterBar is the `Filter: {text}` line below the top border. Cyan, per
+	// the @UI Patterns colour conventions, which give cyan to filter text.
+	FilterBar = lipgloss.NewStyle().
+			Foreground(colorCyan)
+
 	// HintKey is the key name in the bottom hint bar.
 	HintKey = lipgloss.NewStyle().
 		Foreground(colorBlue).


### PR DESCRIPTION
Closes [TAE-57](https://linear.app/taelron/issue/TAE-57/target-filtering). The approved architect plan is the first comment on that issue; this PR implements it as approved, with the two deviations it flagged now carried in the acceptance criteria themselves.

## What was built

`/` activates filter mode over the target list. Runes type into the filter, the list reflows on every keystroke, `Enter` closes the mode keeping the matched results visible, and `Esc` clears the filter before it exits the view.

`/` is **one binding** in `targetKeymap()`. The hint bar and the help overlay are projections of that slice, so both picked it up without an edit — that is the check that this change did not undo the registry TAE-54 built. `renderHintBar` and the help overlay body are untouched in this diff.

### Acceptance criteria

| AC | Where | Pinned by |
| -- | -- | -- |
| `/` activates: `active` true, text empty, cursor 0 | `filter.go` `activateFilter` | `TestSlashActivatesFilterMode`, `TestSlashResetsAPreviousFilter` |
| Runes append, backspace deletes | `model.go` `handleKey` tier 2 | `TestBackspaceDeletesOneRune`, `TestBackspaceReachesTheFilterThroughUpdate` |
| Enter closes the mode, keeps results visible | `keymap_views.go` `enter` | `TestEnterWhileFilteringClosesTheModeAndRunsNothing` |
| Esc: three-state behaviour | `keymap_views.go` `esc` | `TestEscByFilterState` (all four states) |
| Cursor resets to 0 on every text change | `filter.go` `setFilterText` | `TestCursorResetsOnEveryTextChange` |
| Substring match over Name + Description, lowercased | `filter.go` `filtered` | `TestFilteredMatching`, `TestFilteredIsSubstringNotFuzzy` |
| A shared helper, not per-view logic | `filter.go` `filtered[T]` | `TestFilteredIsGenericOverTheItemType` |
| Bar renders whenever the text is non-empty | `model.go` `renderTargetList` | `TestFilterBarRendersOnTheTextNotTheMode` |
| **Row budget drops by two lines when the bar renders** | `model.go` `maxVisible -= 2` | `TestFilterBarDoesNotChangeTheRenderedHeight` |
| **Cursor movement bound against the filtered length** | `keymap_views.go` `down` | `TestDownIsBoundAgainstTheFilteredLength` |
| Hint bar becomes the filterable-list form | projection, not an edit | `TestHintBarsMatchTheBaselineFormats` |
| Help overlay picks `/` up automatically | projection, not an edit | `TestSlashProjectsIntoTheHintBarAndHelp` |
| No match shows the empty state | `model.go` `renderTargetList` | `TestNoMatchShowsItsOwnEmptyState` |
| Projects list stays unfiltered (out of scope) | — | `TestProjectsViewHasNoFilter` |

### Design points worth reading in the diff

**Three-tier dispatch.** `handleKey` is: the modal's keymap (absolute) → filter mode's rune capture → the view's keymap. Tier 2 sits after tier 1's unconditional return, so with a modal up the filter never sees a key. With filter mode off, the path is what it was before.

**Rune capture is not a binding.** A `binding.keys` is a finite list; capture claims the whole rune space, including keys the same keymap already binds. So it is its own tier rather than a second key list. The consequence is deliberate and is in the issue's Notes: while filtering, `g`, `R`, `q`, `j`, `k`, `?` and `/` type instead of firing. A filter for `generate` is untypeable otherwise. Arrows, `Enter`, `Esc` and `Ctrl+C` still dispatch.

**Capture switches on `msg.Type`, not `msg.String()`.** `Key.String()` prefixes `alt+` for alt-modified runes, and a space arrives as `KeySpace` rather than `KeyRunes`. A string test would take `alt+g` as text; a bare `KeyRunes` test would drop the spaces target descriptions are full of.

**`filteredTargets` is the single computation point.** The renderer, the `down` bound check and the `enter` handler all call it, so no call site branches on whether a filter is active. Without it, `enter` runs `proj.Targets[cursor]` — the wrong target whenever a filter is in effect.

### Falsification, not a green run

Every load-bearing claim was checked by reverting it and watching a named test fail:

| sabotage | result |
| -- | -- |
| `maxVisible -= 2` removed | 11/23/39 lines against 10/22/38 |
| `enter` resolving `proj.Targets` | ran `"build"`, want `"verify"` |
| `down` bound on the full list | cursor walked past the only match |
| bar gated on `filter.active` | no bar in the state `Enter` produces |
| capture hoisted above the modal | a rune typed through an open modal |

### One known boundary

Below terminal height 10 the row budget has already hit its floor of one row, so the filter bar's two lines are pure addition and the frame grows by two. The chrome is irreducible at that size — header, top border, bar, separator, column header, separator, bottom border, hint bar is eight lines before a single target row — and the only alternative would be to drop the bar, which the criteria require to render whenever the text is set. The unfiltered view has the same floor one notch lower, so this is pre-existing behaviour rather than something filtering introduced. `TestFilterBarBelowTheChromeFloor` pins the delta at exactly 2 so a future change to it is a deliberate act. Raised during review and accepted by the PO.

## Verification handoff

Run top to bottom from the repo root. All targets already existed; none were added.

| # | Command | Purpose | Expected |
| -- | -- | -- | -- |
| 1 | `make build` | Compiles, including the new generic helper | Binary written, no other output |
| 2 | `make verify-tui` | The whole filter surface: dispatch precedence, cursor reset, match results, the Esc and Enter states, the hint bar string, help contents, empty state, render line count | All pass, including the new filter tests |
| 3 | `make verify` | **Golden oracle.** Discovery behaviour must be unmoved | `TestCharacterization` passes with **no rebaseline**. This PR is `ui/tui` only — if the golden moves, discovery changed and the PR is out of scope |
| 4 | `make verify-parser` | Parser table tests unaffected | All pass |
| 5 | `make verify-guards` | Proves the golden guards still fail on a sabotaged throwaway copy, i.e. step 3's pass is meaningful | Every guard trips; ends with `All guards tripped as required.` |
| 6 | `make test` | Full suite | All pass |
| 7 | `make tidy-check` | No new module churn | Clean; `go.mod`/`go.sum` unchanged |

### Visual sequence

`./mkx` from the repo root — 9 targets, richer than `make run`'s 4-target fixture.

1. `Enter` into a project → hint bar reads `↑↓/Navigate  //Search  Enter/Run  g/Pull  R/Readme  Esc/Back  ?/Help`
2. `?` → the help overlay lists `/  —  Filter by name or description`; `Esc` closes it
3. `/` → type `ver` → `Filter: ver` in cyan below the top border, list narrows, cursor on the first match
4. Backspace ×3 → the full list returns and the bar disappears (filter mode is still active — that is correct)
5. Type `zzz` → `No targets match. Press Esc to clear the filter.`, not a blank area
6. `Esc` → filter cleared, still in the target view. `Esc` again → back to the project list
7. **The one to watch.** Re-enter, `/`, type a match, `Enter` → the bar **stays**, the list stays filtered, and nothing runs. `Enter` again → runs the target the **filtered** cursor points at
8. Projects list: `/` does nothing and the hint bar carries no `//Search`

All eight were also driven headlessly through the real `Update`/`View` during the build session. Step 7 ran `verify-guards` where `proj.Targets[cursor]` would have been `build`.

One thing that reads as a bug and is not: pressing `/` while filter mode is still active types a literal `/` into the filter. That is the documented rune capture, per the issue's Notes.
