### PR TITLE
Stop the golden oracle reporting a cached pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ test: ## Run the full test suite
 	go test ./...
 
 verify: ## Check discovery behaviour against the committed golden
-	go test -v -run TestCharacterization ./internal/app/
+	# -count=1 is load-bearing: without it a cached result replays an earlier
+	# pass, and the oracle reports green without having compared anything.
+	go test -v -count=1 -run TestCharacterization ./internal/app/
 
 verify-parser: ## Run the pure parser table tests
 	go test -v -count=1 ./internal/adapter/makex/


### PR DESCRIPTION
`make verify` had no `-count=1`, so a second run inside the cache window replayed the first run's result and reported `ok (cached)` without comparing anything against the golden. Every other verify target already passes the flag; this one — the only one whose whole job is to be an oracle — did not.

Found by running the TAE-57 verification handoff: step 3 came back `(cached)` on the first attempt, which is a replay, not evidence.

## Proof, both directions

| | run 1 | run 2 |
| -- | -- | -- |
| `go test -run TestCharacterization ./internal/app/` (the old target) | `ok 0.007s` | `ok (cached)` |
| `make verify` (this PR) | `ok 0.007s` | `ok 0.007s` |

The failure mode this closes is narrow but bad: change discovery behaviour, run `make verify` twice, and the second run reports green off a result computed before the change. The guards in `make verify-guards` prove the oracle *fails* when it should; they cannot prove it *ran*.

## Not affected

CI never calls this target — the matrix runs `make test` and the guards job runs `make verify-guards` (`.github/workflows/ci.yml`). Nothing in the pipeline changes.

`make test` still has no `-count=1`. Left alone deliberately: it is a full-suite convenience target, not an oracle, and caching there is a feature. If you want it changed, that is a separate call.

## Verification handoff

| # | Command | Purpose | Expected |
| -- | -- | -- | -- |
| 1 | `make verify` | The change itself | `TestCharacterization` passes |
| 2 | `make verify` again, immediately | The point of the PR | Passes again with a **timing figure, never `(cached)`** |
| 3 | `make verify-guards` | The oracle's guards still trip on a sabotaged copy | `All guards tripped as required.` |
| 4 | `make test` | Nothing else moved | All pass |

No Linear issue: this is a one-line fix to the verification surface, found while running TAE-57's handoff, and it carries a `Refs TAE-57` trailer. Say the word if you would rather it had its own issue.
