### PR TITLE
Git state: GitReader port, gitx adapter, and branch display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY   := mkx
 FIXTURES := testdata/fixtures
 
-.PHONY: build test verify verify-parser verify-tui verify-guards rebaseline-golden tidy-check run
+.PHONY: build test verify verify-parser verify-gitx verify-tui verify-guards rebaseline-golden tidy-check run demo-git
 
 build: ## Compile the mkx binary
 	go build -o $(BINARY) ./cmd/mkx
@@ -16,6 +16,11 @@ verify: ## Check discovery behaviour against the committed golden
 
 verify-parser: ## Run the pure parser table tests
 	go test -v -count=1 ./internal/adapter/makex/
+
+verify-gitx: ## Run the pure git classifier and parser table tests
+	# No git process is spawned by these: they drive the classifiers from
+	# captured strings, so they pass identically on a box with no git.
+	go test -v -count=1 ./internal/adapter/gitx/
 
 verify-tui: ## Run the TUI keymap, modal and overlay tests by name
 	go test -v -count=1 ./internal/ui/tui/
@@ -32,3 +37,6 @@ tidy-check: ## Fail if go.mod/go.sum are not tidy
 
 run: build ## Launch the TUI against testdata/fixtures
 	cd $(FIXTURES) && $(CURDIR)/$(BINARY)
+
+demo-git: build ## Build a throwaway workspace covering every git display state
+	./scripts/demo-git.sh

--- a/cmd/mkx/main.go
+++ b/cmd/mkx/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Gaetan-Jaminon/mkx/internal/adapter/gitx"
 	"github.com/Gaetan-Jaminon/mkx/internal/adapter/makex"
 	"github.com/Gaetan-Jaminon/mkx/internal/adapter/workspace"
 	"github.com/Gaetan-Jaminon/mkx/internal/app"
@@ -39,6 +40,7 @@ func main() {
 	application := app.New(
 		workspace.NewScanner(workspace.DefaultExcludes, workspace.DefaultMaxDepth),
 		makex.NewRunner(),
+		gitx.NewReader(),
 	)
 
 	projects, err := application.DiscoverProjects(rootCtx, root)

--- a/internal/adapter/gitx/gitx.go
+++ b/internal/adapter/gitx/gitx.go
@@ -1,0 +1,173 @@
+// Package gitx is the git adapter: it reads a repository's state through
+// short, captured, read-only commands.
+//
+// Per ADR-M003 the distinction MkX draws is mutating vs reading, not git vs
+// make. Mutating commands — `git pull`, `git checkout` — own the terminal and
+// run through the handover path in ui/tui. Reading commands return a value and
+// never touch the terminal; those are what this package runs.
+//
+// This file holds the impure edges: spawning git and composing the three reads.
+// The classification and parsing are in parse.go and are pure.
+package gitx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/app"
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+)
+
+// Reader reads git state through the git binary. Construct it with NewReader.
+//
+// Per ADR-M003 MkX deliberately does not use go-git: the git binary is the
+// same source of truth the user's other tooling reads, and a second one can
+// disagree with it.
+type Reader struct{}
+
+var _ app.GitReader = (*Reader)(nil)
+
+// NewReader returns a Reader.
+func NewReader() *Reader {
+	return &Reader{}
+}
+
+// State reports the state of the repository containing dir.
+//
+// dir need not be a repository root: git's own upward .git discovery resolves
+// every command below to the containing repository, which is what satisfies
+// the Domain Model's containing-repository rule. There is no root-walking code
+// here and no `rev-parse --show-toplevel` call — it would be a fourth
+// subprocess computing a value nothing consumes.
+//
+// It returns app.ErrNotARepository when dir is inside no repository. Any other
+// error means the read failed; the caller renders that as unknown, never as
+// clean.
+//
+// The caller owns the deadline. State spawns nothing once ctx is done.
+func (r *Reader) State(ctx context.Context, dir string) (domain.RepoState, error) {
+	head := classifyHead(run(ctx, dir, "rev-parse", "--abbrev-ref", "HEAD"))
+
+	// rev-parse gates the other two. If there is no repository, or the read
+	// failed, running status and branch would spawn two more processes to
+	// produce output that is already known to be unusable.
+	switch head.kind {
+	case headAbsent:
+		return domain.RepoState{}, app.ErrNotARepository
+	case headFailed:
+		return domain.RepoState{}, head.err
+	}
+
+	// Unborn deliberately does not gate: status and branch both work on a
+	// repository with no commits, and both are meaningful there.
+
+	status := run(ctx, dir, "status", "--porcelain")
+	if err := status.failure(); err != nil {
+		// Checked rather than ignored. An unchecked failure here returns empty
+		// output, and parseDirty("") would fabricate Dirty:false — the
+		// "absence reads as clean" bug relocated one call deeper.
+		return domain.RepoState{}, fmt.Errorf("git status: %w", err)
+	}
+
+	branch := run(ctx, dir, "branch")
+	if err := branch.failure(); err != nil {
+		return domain.RepoState{}, fmt.Errorf("git branch: %w", err)
+	}
+
+	return domain.RepoState{
+		Head:     head.head,
+		Branch:   head.branch,
+		Dirty:    parseDirty(status.stdout),
+		Branches: parseBranches(branch.stdout),
+	}, nil
+}
+
+// result is one captured git subprocess. It is a plain struct with no
+// behaviour tied to exec, so parse.go's classifiers can be driven from a table
+// of literals rather than from a real git run.
+type result struct {
+	stdout   string
+	stderr   string
+	exitCode int
+	ctxErr   error
+}
+
+// failure returns a non-nil error when the command did not complete
+// successfully. It is the check for the two reads whose output is only
+// meaningful on success; rev-parse's richer outcomes go through classifyHead.
+func (r result) failure() error {
+	if r.ctxErr != nil {
+		return r.ctxErr
+	}
+	if r.exitCode != 0 {
+		return fmt.Errorf("exit %d: %s", r.exitCode, firstLine(r.stderr))
+	}
+	return nil
+}
+
+// run captures one git command against dir.
+//
+// Everything about the invocation is deliberate:
+//
+//   - --no-optional-locks and -C are top-level git options and must precede the
+//     subcommand; placed after it, git rejects them outright.
+//   - --no-optional-locks stops `git status` opportunistically refreshing and
+//     locking the index. That converts "may block on another process's
+//     index.lock" into "never attempts the lock" — a stronger guarantee than
+//     the timeout, which would only bound the wait.
+//   - LC_ALL/LANG pin git's fatals to English, which classifyHead matches on.
+//     This matters more here than in makex: without it, a non-English git
+//     silently degrades both absent and unborn to unknown.
+//   - GIT_TERMINAL_PROMPT=0 enforces ADR-M003's non-interactive constraint.
+//     None of the three reads touch a remote, so it costs nothing today; it is
+//     there so a future edit that does cannot hang on a credential prompt.
+//
+// stdout and stderr go to buffers, never to the process's own — these are
+// captured reads, never handover.
+func run(ctx context.Context, dir string, args ...string) result {
+	argv := append([]string{"--no-optional-locks", "-C", dir}, args...)
+
+	cmd := exec.CommandContext(ctx, "git", argv...)
+	cmd.Stdin = nil
+	cmd.Env = append(os.Environ(),
+		"LC_ALL=C",
+		"LANG=C",
+		"GIT_TERMINAL_PROMPT=0",
+	)
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	res := result{stdout: stdout.String(), stderr: stderr.String()}
+
+	// The context is consulted directly rather than inferred from err. A
+	// killed process surfaces as a plain *ExitError, so exit status alone
+	// cannot tell a timeout apart from a repository that is genuinely broken.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		res.ctxErr = ctxErr
+		return res
+	}
+
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			res.exitCode = exitErr.ExitCode()
+		} else {
+			// git could not be started at all — not on PATH, or not
+			// executable. Not a repository state; a failed read.
+			res.exitCode = -1
+			if res.stderr == "" {
+				res.stderr = err.Error()
+			}
+		}
+	}
+
+	return res
+}

--- a/internal/adapter/gitx/gitx.go
+++ b/internal/adapter/gitx/gitx.go
@@ -73,7 +73,11 @@ func (r *Reader) State(ctx context.Context, dir string) (domain.RepoState, error
 		return domain.RepoState{}, fmt.Errorf("git status: %w", err)
 	}
 
-	branch := run(ctx, dir, "branch")
+	// --format per ADR-M003, which names `git branch --format=...` as the
+	// permitted read. It drops the two-character marker column ("* ", "+ ",
+	// "  ") entirely, so there is no column to strip and no marker character
+	// that could be mistaken for part of a branch name.
+	branch := run(ctx, dir, "branch", "--format=%(refname:short)")
 	if err := branch.failure(); err != nil {
 		return domain.RepoState{}, fmt.Errorf("git branch: %w", err)
 	}

--- a/internal/adapter/gitx/parse.go
+++ b/internal/adapter/gitx/parse.go
@@ -117,17 +117,24 @@ func parseDirty(porcelain string) bool {
 	return false
 }
 
-// parseBranches extracts the local branch names from `git branch` output.
+// parseBranches extracts the local branch names from
+// `git branch --format=%(refname:short)` output.
 //
-// Each line carries a two-character marker column — "  " for a branch, "* "
-// for the checked-out one, "+ " for one checked out in another worktree —
-// which is stripped rather than matched, so a new marker character does not
-// silently become part of a branch name.
+// The format is the one ADR-M003 names, and it gives one bare branch name per
+// line: no two-character marker column, so no column to strip and no marker
+// character that could silently become part of a name.
 //
-// A detached head adds a pseudo-entry that is not a branch: "* (HEAD detached
-// at d377e56)", or "* (no branch)" in older phrasings. Those are dropped by
-// shape — parenthesised, and containing a space, which git's own refname
-// rules forbid in a real branch name.
+// What --format does NOT remove is the pseudo-entry git synthesises when HEAD
+// is not on a branch. Verified against git 2.47.3, both of these appear in
+// --format output alongside the real branches:
+//
+//	(HEAD detached at c5020c5)
+//	(no branch, bisect started on main)
+//
+// They are not branches and must never reach a list offered for selection, so
+// they are dropped by shape rather than by matching either phrasing: a
+// parenthesised entry containing a space. git's own refname rules forbid a
+// space in a real branch name, so the rule cannot discard one.
 //
 // A repository with no commits yet produces no output at all, and therefore
 // no branches. That is a correct empty list, not a failed read; the caller
@@ -136,11 +143,7 @@ func parseBranches(out string) []string {
 	var branches []string
 	scanner := bufio.NewScanner(strings.NewReader(out))
 	for scanner.Scan() {
-		line := scanner.Text()
-		if len(line) >= 2 {
-			line = line[2:]
-		}
-		name := strings.TrimSpace(line)
+		name := strings.TrimSpace(scanner.Text())
 		if name == "" {
 			continue
 		}

--- a/internal/adapter/gitx/parse.go
+++ b/internal/adapter/gitx/parse.go
@@ -1,0 +1,165 @@
+package gitx
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+)
+
+// This file holds the parsing half of the git adapter. Every function here is
+// pure: it takes one captured `result` and returns values, running no
+// subprocess and reading no file. The impure edge — spawning git — lives in
+// gitx.go, so the classifiers are table-testable without git on the box and
+// without a repository to point them at (ADR-M003, and the same split ADR-M002
+// established for makex).
+
+// headKind is what a `git rev-parse --abbrev-ref HEAD` read established about
+// the directory it was run in.
+type headKind int
+
+const (
+	// headFailed means the read gave no usable answer: it timed out, was
+	// cancelled, or git failed for a reason that is not "no repository here".
+	// The state is unknown, which is emphatically not "clean".
+	headFailed headKind = iota
+	// headAbsent means the directory is inside no git repository. Per the MkX
+	// Domain Model this is an absence, not a failure.
+	headAbsent
+	// headPresent means a repository was found and its HEAD resolved.
+	headPresent
+)
+
+// headOutcome is classifyHead's result: which of the three kinds above, plus
+// the detail that kind carries.
+type headOutcome struct {
+	kind headKind
+
+	// head is meaningful only when kind is headPresent. It is never
+	// HeadUnknown there.
+	head domain.Head
+
+	// branch is set only when head is domain.HeadOnBranch.
+	branch string
+
+	// err is set only when kind is headFailed, and describes why.
+	err error
+}
+
+// classifyHead turns one captured `git rev-parse --abbrev-ref HEAD` into a
+// head outcome.
+//
+// The order of the rules is load-bearing twice over.
+//
+// ctxErr is checked first and wins unconditionally: a process the context
+// killed may still have written an exit code and a stderr line, and neither is
+// evidence about the repository.
+//
+// The exit code is checked before stdout because git prints the literal
+// "HEAD" on stdout in BOTH the detached case (exit 0) and the unborn case
+// (exit 128, with the ambiguous-argument fatal on stderr). A classifier that
+// reads stdout first reports an empty repository as detached. Verified against
+// git 2.47.3.
+func classifyHead(r result) headOutcome {
+	if r.ctxErr != nil {
+		return headOutcome{kind: headFailed, err: fmt.Errorf("git rev-parse: %w", r.ctxErr)}
+	}
+
+	if r.exitCode == 0 {
+		name := strings.TrimSpace(r.stdout)
+		if name == "HEAD" {
+			return headOutcome{kind: headPresent, head: domain.HeadDetached}
+		}
+		if name == "" {
+			// Exit 0 with nothing to name the head is not a state git
+			// produces; treating it as a branch called "" would render as a
+			// clean repository on a nameless branch.
+			return headOutcome{kind: headFailed, err: fmt.Errorf("git rev-parse: empty output")}
+		}
+		return headOutcome{kind: headPresent, head: domain.HeadOnBranch, branch: name}
+	}
+
+	// Below here git failed. Only two failures are known states rather than
+	// broken reads, and both are matched on git's English text — which is why
+	// gitx.go pins LC_ALL=C. Without the pin a non-English git degrades both
+	// of these to unknown rather than mis-reporting them.
+	stderr := r.stderr
+	switch {
+	case strings.Contains(stderr, "fatal: not a git repository"):
+		return headOutcome{kind: headAbsent}
+	case strings.Contains(stderr, "ambiguous argument 'HEAD'"):
+		// A repository with no commits yet. It is a real repository: status
+		// and branch both work there and both are meaningful.
+		return headOutcome{kind: headPresent, head: domain.HeadUnborn}
+	}
+
+	// Everything else — a missing directory, an invalid gitfile, a permission
+	// error, a git that is not on PATH. Exit 128 is necessary but never
+	// sufficient: git uses it for every fatal, so an unmatched 128 lands here
+	// rather than being guessed at.
+	return headOutcome{kind: headFailed, err: fmt.Errorf("git rev-parse: exit %d: %s", r.exitCode, firstLine(stderr))}
+}
+
+// parseDirty reports whether `git status --porcelain` output shows any
+// uncommitted change — modified, staged, or untracked alike.
+//
+// Any non-blank line is a change. The porcelain v1 format gives one line per
+// path with a two-character status prefix, and prints nothing at all for a
+// clean tree.
+func parseDirty(porcelain string) bool {
+	scanner := bufio.NewScanner(strings.NewReader(porcelain))
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// parseBranches extracts the local branch names from `git branch` output.
+//
+// Each line carries a two-character marker column — "  " for a branch, "* "
+// for the checked-out one, "+ " for one checked out in another worktree —
+// which is stripped rather than matched, so a new marker character does not
+// silently become part of a branch name.
+//
+// A detached head adds a pseudo-entry that is not a branch: "* (HEAD detached
+// at d377e56)", or "* (no branch)" in older phrasings. Those are dropped by
+// shape — parenthesised, and containing a space, which git's own refname
+// rules forbid in a real branch name.
+//
+// A repository with no commits yet produces no output at all, and therefore
+// no branches. That is a correct empty list, not a failed read; the caller
+// distinguishes the two by the head outcome, never by this being empty.
+func parseBranches(out string) []string {
+	var branches []string
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) >= 2 {
+			line = line[2:]
+		}
+		name := strings.TrimSpace(line)
+		if name == "" {
+			continue
+		}
+		if strings.HasPrefix(name, "(") && strings.HasSuffix(name, ")") && strings.Contains(name, " ") {
+			continue
+		}
+		branches = append(branches, name)
+	}
+	return branches
+}
+
+// firstLine returns the first non-blank line of s, trimmed — enough to name
+// what went wrong without pasting git's multi-line advice into an error.
+func firstLine(s string) string {
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	for scanner.Scan() {
+		if line := strings.TrimSpace(scanner.Text()); line != "" {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/adapter/gitx/parse_test.go
+++ b/internal/adapter/gitx/parse_test.go
@@ -250,37 +250,45 @@ func TestParseBranches(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "plain list with the current-branch marker stripped",
-			in: `  develop
-* main
-  gaetanjaminon/tae-58
+			// --format gives one bare name per line, with no marker column.
+			name: "bare list",
+			in: `develop
+main
+gaetanjaminon/tae-58
 `,
 			want: []string{"develop", "main", "gaetanjaminon/tae-58"},
 		},
 		{
-			// git 2.47.3 emits this pseudo-entry alongside the real branches
-			// when HEAD is detached. It is not a branch and must not appear in
-			// a list offered for selection.
+			// --format drops the marker column but NOT this. git 2.47.3 still
+			// synthesises it alongside the real branches when HEAD is
+			// detached, and it is not a branch.
 			name: "detached pseudo-entry dropped, real branches kept",
-			in: `* (HEAD detached at 9d77cf6)
-  main
-  develop
+			in: `(HEAD detached at c5020c5)
+main
+develop
 `,
 			want: []string{"main", "develop"},
 		},
 		{
-			name: "older no-branch phrasing dropped",
-			in: `* (no branch)
-  main
+			// A second phrasing, captured from git 2.47.3 --format output
+			// while bisecting. The filter is by shape rather than by matching
+			// either wording, which is what makes this one drop too without
+			// the parser having to enumerate git's phrasings.
+			name: "a differently-worded pseudo-entry is dropped by the same rule",
+			in: `(no branch, bisect started on main)
+develop
+main
 `,
-			want: []string{"main"},
+			want: []string{"develop", "main"},
 		},
 		{
-			name: "worktree marker stripped like any other",
-			in: `+ feature/wt
-* main
-`,
-			want: []string{"feature/wt", "main"},
+			// The shape rule must not be so broad it discards a real branch.
+			// A parenthesised name with no space is a legal refname, so it is
+			// kept — the space is what separates a pseudo-entry from a branch
+			// someone genuinely named oddly.
+			name: "a parenthesised name with no space is a real branch",
+			in:   "(weird)\nmain\n",
+			want: []string{"(weird)", "main"},
 		},
 		{
 			// A repository with no commits yet. Zero branches is the correct
@@ -292,12 +300,12 @@ func TestParseBranches(t *testing.T) {
 		},
 		{
 			name: "blank lines ignored",
-			in:   "  main\n\n  develop\n",
+			in:   "main\n\ndevelop\n",
 			want: []string{"main", "develop"},
 		},
 		{
 			name: "no trailing newline",
-			in:   "* main",
+			in:   "main",
 			want: []string{"main"},
 		},
 	}
@@ -317,12 +325,12 @@ func TestParseBranches(t *testing.T) {
 	}
 }
 
-// TestParseBranchesKeepsNamesUntrimmedOfContent guards the two-character strip
-// against eating a branch name. The marker column is exactly two characters;
-// a name is never shortened by it.
-func TestParseBranchesKeepsNamesUntrimmedOfContent(t *testing.T) {
+// TestParseBranchesKeepsShortNames guards against a name being eaten by
+// anything that trims from the front. Two characters is the length the old
+// marker-column strip would have consumed entirely.
+func TestParseBranchesKeepsShortNames(t *testing.T) {
 	const name = "ab"
-	got := parseBranches("  " + name + "\n")
+	got := parseBranches(name + "\n")
 	if len(got) != 1 || got[0] != name {
 		t.Errorf("parseBranches lost content: got %v, want [%q]", got, name)
 	}

--- a/internal/adapter/gitx/parse_test.go
+++ b/internal/adapter/gitx/parse_test.go
@@ -1,0 +1,389 @@
+package gitx
+
+// Table tests for the pure classification core. Per TAE-58's acceptance
+// criteria the adapter logic is tested against captured command output as a
+// pure function, not by invoking git: nothing in this file spawns a process,
+// touches the filesystem, or needs a repository to point at. Every input is a
+// literal, visible in the test.
+//
+// The captured strings below were taken from git 2.47.3 under LC_ALL=C, which
+// is the locale gitx.go pins. Two of them are the reason this file exists:
+// detached and unborn both print "HEAD" on stdout and differ only in the exit
+// code.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+)
+
+// Real stderr text from git 2.47.3, kept verbatim — including the trailing
+// advice lines — because classifyHead matches on substrings of it and a
+// hand-tidied sample would not prove the match survives the real output.
+const (
+	stderrNoRepo = `fatal: not a git repository (or any parent up to mount point /)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+`
+	// The other phrasing, emitted when discovery stops for a reason other than
+	// a mount boundary. Both must classify as absent.
+	stderrNoRepoShort = "fatal: not a git repository: /w/broken/garbage\n"
+
+	stderrUnborn = `fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
+Use '--' to separate paths from revisions, like this:
+'git <command> [<revision>...] -- [<file>...]'
+`
+	stderrMissingDir  = "fatal: cannot change to '/w/gone': No such file or directory\n"
+	stderrInvalidFile = "fatal: invalid gitfile format: /w/broken/.git\n"
+)
+
+func TestClassifyHead(t *testing.T) {
+	tests := []struct {
+		name string
+		in   result
+
+		wantKind   headKind
+		wantHead   domain.Head
+		wantBranch string
+	}{
+		{
+			name:       "on a branch",
+			in:         result{stdout: "main\n"},
+			wantKind:   headPresent,
+			wantHead:   domain.HeadOnBranch,
+			wantBranch: "main",
+		},
+		{
+			name:       "branch name with slashes is not mangled",
+			in:         result{stdout: "gaetanjaminon/tae-58-git-state\n"},
+			wantKind:   headPresent,
+			wantHead:   domain.HeadOnBranch,
+			wantBranch: "gaetanjaminon/tae-58-git-state",
+		},
+		{
+			// git 2.47.3: exit 0, stdout "HEAD". The exit code is the ONLY
+			// thing separating this from the unborn case below.
+			name:     "detached HEAD is detached, not a branch named HEAD",
+			in:       result{stdout: "HEAD\n"},
+			wantKind: headPresent,
+			wantHead: domain.HeadDetached,
+		},
+		{
+			// git 2.47.3: exit 128, stdout "HEAD", ambiguous-argument stderr.
+			// The regression test for the single most load-bearing finding in
+			// the design: a classifier reading stdout before the exit code
+			// reports an empty repository as detached.
+			name: "unborn HEAD is unborn, not detached, despite the same stdout",
+			in: result{
+				stdout:   "HEAD\n",
+				stderr:   stderrUnborn,
+				exitCode: 128,
+			},
+			wantKind: headPresent,
+			wantHead: domain.HeadUnborn,
+		},
+		{
+			name:     "not a repository, mount-boundary phrasing",
+			in:       result{stderr: stderrNoRepo, exitCode: 128},
+			wantKind: headAbsent,
+		},
+		{
+			name:     "not a repository, path phrasing",
+			in:       result{stderr: stderrNoRepoShort, exitCode: 128},
+			wantKind: headAbsent,
+		},
+		{
+			// Exit 128 is necessary but never sufficient — git uses it for
+			// every fatal. An unmatched 128 must land in failed rather than
+			// being guessed at as absent.
+			name:     "missing directory is a failed read, not an absent repo",
+			in:       result{stderr: stderrMissingDir, exitCode: 128},
+			wantKind: headFailed,
+		},
+		{
+			name:     "invalid gitfile is a failed read, not an absent repo",
+			in:       result{stderr: stderrInvalidFile, exitCode: 128},
+			wantKind: headFailed,
+		},
+		{
+			name:     "git could not be started",
+			in:       result{stderr: `exec: "git": executable file not found in $PATH`, exitCode: -1},
+			wantKind: headFailed,
+		},
+		{
+			name:     "timeout",
+			in:       result{ctxErr: context.DeadlineExceeded},
+			wantKind: headFailed,
+		},
+		{
+			// The trap case. A context-killed process may still have written
+			// an exit code and a stderr line, and neither is evidence about
+			// the repository. If the stderr rules ran first this would report
+			// a perfectly fine repository as absent and stop MkX ever
+			// retrying it. Proves the ctx-first rule rather than assuming it.
+			name: "context error wins over a not-a-repository stderr",
+			in: result{
+				stderr:   stderrNoRepo,
+				exitCode: 128,
+				ctxErr:   context.DeadlineExceeded,
+			},
+			wantKind: headFailed,
+		},
+		{
+			name: "context error wins over a successful exit",
+			in: result{
+				stdout: "main\n",
+				ctxErr: context.Canceled,
+			},
+			wantKind: headFailed,
+		},
+		{
+			// Not a state git produces. Taking it as a branch named "" would
+			// render as a clean repository on a nameless branch — exactly the
+			// "absence reads as clean" failure the AC forbids.
+			name:     "exit 0 with empty output is a failed read",
+			in:       result{stdout: "\n"},
+			wantKind: headFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyHead(tt.in)
+
+			if got.kind != tt.wantKind {
+				t.Fatalf("kind = %v, want %v (outcome %+v)", got.kind, tt.wantKind, got)
+			}
+			if got.head != tt.wantHead {
+				t.Errorf("head = %v, want %v", got.head, tt.wantHead)
+			}
+			if got.branch != tt.wantBranch {
+				t.Errorf("branch = %q, want %q", got.branch, tt.wantBranch)
+			}
+
+			// A failed outcome must carry a reason: it is what the caller
+			// wraps and what a future diagnostic surface would show.
+			if tt.wantKind == headFailed && got.err == nil {
+				t.Errorf("kind is headFailed but err is nil")
+			}
+			if tt.wantKind != headFailed && got.err != nil {
+				t.Errorf("err = %v on a %v outcome, want nil", got.err, tt.wantKind)
+			}
+		})
+	}
+}
+
+// TestClassifyHeadPreservesContextError checks the timeout is not merely
+// reported as some error, but as one the caller can still test with
+// errors.Is — the TUI discards a cancellation silently and shows a timeout,
+// and it cannot tell them apart from an error string.
+func TestClassifyHeadPreservesContextError(t *testing.T) {
+	for _, want := range []error{context.DeadlineExceeded, context.Canceled} {
+		got := classifyHead(result{ctxErr: want})
+		if !errors.Is(got.err, want) {
+			t.Errorf("classifyHead(ctxErr=%v).err = %v, want it to wrap %v", want, got.err, want)
+		}
+	}
+}
+
+// TestClassifyHeadNeverReportsUnknownHeadAsPresent pins the invariant the
+// display layer relies on: a present outcome always names a real head state,
+// so the renderer never has to treat domain.HeadUnknown as "we did read this".
+func TestClassifyHeadNeverReportsUnknownHeadAsPresent(t *testing.T) {
+	inputs := []result{
+		{stdout: "main\n"},
+		{stdout: "HEAD\n"},
+		{stdout: "HEAD\n", stderr: stderrUnborn, exitCode: 128},
+	}
+	for _, in := range inputs {
+		got := classifyHead(in)
+		if got.kind == headPresent && got.head == domain.HeadUnknown {
+			t.Errorf("classifyHead(%+v) reported present with HeadUnknown", in)
+		}
+	}
+}
+
+func TestParseDirty(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "clean tree produces no output", in: "", want: false},
+		{name: "whitespace only", in: "\n  \n\t\n", want: false},
+		{name: "modified", in: " M internal/app/ports.go\n", want: true},
+		{name: "staged", in: "M  internal/domain/domain.go\n", want: true},
+		{name: "untracked only", in: "?? internal/adapter/gitx/\n", want: true},
+		{name: "deleted", in: " D README.md\n", want: true},
+		{name: "renamed", in: "R  old.go -> new.go\n", want: true},
+		{
+			name: "several lines",
+			in: ` M internal/app/ports.go
+M  internal/domain/domain.go
+?? internal/adapter/gitx/
+`,
+			want: true,
+		},
+		{
+			name: "no trailing newline",
+			in:   " M internal/app/ports.go",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseDirty(tt.in); got != tt.want {
+				t.Errorf("parseDirty(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseBranches(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "plain list with the current-branch marker stripped",
+			in: `  develop
+* main
+  gaetanjaminon/tae-58
+`,
+			want: []string{"develop", "main", "gaetanjaminon/tae-58"},
+		},
+		{
+			// git 2.47.3 emits this pseudo-entry alongside the real branches
+			// when HEAD is detached. It is not a branch and must not appear in
+			// a list offered for selection.
+			name: "detached pseudo-entry dropped, real branches kept",
+			in: `* (HEAD detached at 9d77cf6)
+  main
+  develop
+`,
+			want: []string{"main", "develop"},
+		},
+		{
+			name: "older no-branch phrasing dropped",
+			in: `* (no branch)
+  main
+`,
+			want: []string{"main"},
+		},
+		{
+			name: "worktree marker stripped like any other",
+			in: `+ feature/wt
+* main
+`,
+			want: []string{"feature/wt", "main"},
+		},
+		{
+			// A repository with no commits yet. Zero branches is the correct
+			// answer here, not a failed read — the caller distinguishes the
+			// two by the head outcome, never by this being empty.
+			name: "empty output yields no branches",
+			in:   "",
+			want: nil,
+		},
+		{
+			name: "blank lines ignored",
+			in:   "  main\n\n  develop\n",
+			want: []string{"main", "develop"},
+		},
+		{
+			name: "no trailing newline",
+			in:   "* main",
+			want: []string{"main"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseBranches(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseBranches(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseBranches(%q)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestParseBranchesKeepsNamesUntrimmedOfContent guards the two-character strip
+// against eating a branch name. The marker column is exactly two characters;
+// a name is never shortened by it.
+func TestParseBranchesKeepsNamesUntrimmedOfContent(t *testing.T) {
+	const name = "ab"
+	got := parseBranches("  " + name + "\n")
+	if len(got) != 1 || got[0] != name {
+		t.Errorf("parseBranches lost content: got %v, want [%q]", got, name)
+	}
+}
+
+// TestResultFailure covers the check that stops a timed-out `git status`
+// returning empty output and being parsed as a clean tree.
+func TestResultFailure(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      result
+		wantErr bool
+	}{
+		{name: "success", in: result{stdout: " M x.go\n"}, wantErr: false},
+		{name: "clean success", in: result{}, wantErr: false},
+		{name: "non-zero exit", in: result{exitCode: 128, stderr: stderrMissingDir}, wantErr: true},
+		{name: "timeout with empty output", in: result{ctxErr: context.DeadlineExceeded}, wantErr: true},
+		{
+			// The specific bug this method exists to prevent: a killed read
+			// looks exactly like a clean tree if only stdout is consulted.
+			name:    "timeout that also exited zero",
+			in:      result{stdout: "", ctxErr: context.DeadlineExceeded},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.in.failure()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("failure() = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestFirstLine checks the error-string helper drops git's multi-line advice.
+func TestFirstLine(t *testing.T) {
+	if got := firstLine(stderrNoRepo); got != "fatal: not a git repository (or any parent up to mount point /)" {
+		t.Errorf("firstLine = %q", got)
+	}
+	if got := firstLine("\n\n  fatal: x\n"); got != "fatal: x" {
+		t.Errorf("firstLine skipping blanks = %q", got)
+	}
+	if got := firstLine(""); got != "" {
+		t.Errorf("firstLine(\"\") = %q, want empty", got)
+	}
+}
+
+// TestNoGitInvokedByParsers is a non-vacuity check on the claim this file
+// makes in its header. It does not attempt to intercept exec — it asserts the
+// weaker, verifiable thing: that the pure file declares no dependency capable
+// of spawning a process.
+func TestNoGitInvokedByParsers(t *testing.T) {
+	src, err := os.ReadFile("parse.go")
+	if err != nil {
+		t.Fatalf("reading parse.go: %v", err)
+	}
+	for _, forbidden := range []string{`"os/exec"`, `"os"`} {
+		if strings.Contains(string(src), forbidden) {
+			t.Errorf("parse.go imports %s; the parsing half must stay pure", forbidden)
+		}
+	}
+}

--- a/internal/app/characterization_test.go
+++ b/internal/app/characterization_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Gaetan-Jaminon/mkx/internal/adapter/gitx"
 	"github.com/Gaetan-Jaminon/mkx/internal/adapter/makex"
 	"github.com/Gaetan-Jaminon/mkx/internal/adapter/workspace"
 	"github.com/Gaetan-Jaminon/mkx/internal/app"
@@ -53,6 +54,11 @@ func TestCharacterization(t *testing.T) {
 	application := app.New(
 		workspace.NewScanner(workspace.DefaultExcludes, characterizationDepth),
 		makex.NewRunner(),
+		// Wired only so this compiles. DiscoverProjects never calls the git
+		// reader, and serializeProjects reads no git state — which is why the
+		// golden below is byte-identical across this change. A diff here means
+		// something touched discovery.
+		gitx.NewReader(),
 	)
 
 	projects, err := application.DiscoverProjects(context.Background(), root)

--- a/internal/app/ports.go
+++ b/internal/app/ports.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 
 	"github.com/Gaetan-Jaminon/mkx/internal/domain"
 )
@@ -25,4 +26,25 @@ type MakeRunner interface {
 
 	// TargetCommand returns the command that runs the named target in dir.
 	TargetCommand(ctx context.Context, dir, name string) domain.Command
+}
+
+// ErrNotARepository is returned by GitReader.State when dir is not inside a
+// git repository at all.
+//
+// Per the MkX Domain Model this is an absence, not a failure: a Project
+// outside a repository simply has no RepoState. It is declared here rather
+// than in the adapter because ui/tui needs errors.Is on it, and ui/tui must
+// not import an adapter (ADR-M001).
+var ErrNotARepository = errors.New("not a git repository")
+
+// GitReader reads git state. It never mutates — per ADR-M003 pull and
+// checkout are handovers, not reads.
+type GitReader interface {
+	// State resolves dir to the repository containing it — dir need not be a
+	// repository root — and reports that repository's state.
+	//
+	// It returns ErrNotARepository when dir is inside no repository. Any
+	// other error means the read failed and the caller treats the state as
+	// unknown; it never means the tree is clean.
+	State(ctx context.Context, dir string) (domain.RepoState, error)
 }

--- a/internal/app/usecases.go
+++ b/internal/app/usecases.go
@@ -7,19 +7,37 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Gaetan-Jaminon/mkx/internal/domain"
 )
+
+// gitReadTimeout bounds one whole RepoState read — all three git commands,
+// not one deadline each. ADR-M003 requires captured reads to be bounded; the
+// AC asks for "a context with a timeout", singular. When the budget runs out
+// mid-sequence the next command fails immediately rather than spawning.
+//
+// A warm local read of these commands is single-digit milliseconds. A cold or
+// very large working tree can push `status --porcelain` into the hundreds,
+// occasionally past a second on networked storage. The index-lock hazard is
+// eliminated by --no-optional-locks in the adapter rather than budgeted for
+// here. Two seconds is roughly two orders of magnitude above a warm read and
+// still short enough that a genuinely stuck read resolves while the user is
+// looking at the view.
+//
+// Unexported and unconfigurable, per ADR-M004.
+const gitReadTimeout = 2 * time.Second
 
 // App composes the ports into MkX's use cases. Constructed in cmd/mkx/main.go.
 type App struct {
 	scanner WorkspaceScanner
 	runner  MakeRunner
+	git     GitReader
 }
 
 // New wires the adapters behind their ports.
-func New(scanner WorkspaceScanner, runner MakeRunner) *App {
-	return &App{scanner: scanner, runner: runner}
+func New(scanner WorkspaceScanner, runner MakeRunner, git GitReader) *App {
+	return &App{scanner: scanner, runner: runner, git: git}
 }
 
 // DiscoverProjects walks the workspace, discovers each project's targets, and
@@ -67,6 +85,23 @@ func (a *App) PullAndRefresh(ctx context.Context, project domain.Project) (domai
 // RefreshTargets re-discovers a project's targets after a handover.
 func (a *App) RefreshTargets(ctx context.Context, project domain.Project) ([]domain.Target, error) {
 	return a.runner.Discover(ctx, project.Path)
+}
+
+// RepoState reads the git state of the repository containing the project.
+//
+// It returns ErrNotARepository when the project is in no repository — an
+// absence, not a failure. Any other error means the read did not produce a
+// usable answer and the caller must render unknown, never clean.
+//
+// The deadline is applied here rather than in the adapter for two reasons.
+// Bounding a read is a policy, and app is the port's only caller; and it is
+// the only placement a test can assert, since a fake GitReader can check
+// ctx.Deadline() where an adapter-side timeout would need a deliberately slow
+// subprocess to exercise.
+func (a *App) RepoState(ctx context.Context, project domain.Project) (domain.RepoState, error) {
+	ctx, cancel := context.WithTimeout(ctx, gitReadTimeout)
+	defer cancel()
+	return a.git.State(ctx, project.Path)
 }
 
 // ReadmePath returns the project's README path, or "" when it has none.

--- a/internal/app/usecases_test.go
+++ b/internal/app/usecases_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Gaetan-Jaminon/mkx/internal/app"
 	"github.com/Gaetan-Jaminon/mkx/internal/domain"
@@ -36,7 +37,94 @@ func (f *fakeRunner) TargetCommand(_ context.Context, dir, name string) domain.C
 	return domain.Command{Argv: []string{"make", name}, WorkDir: dir}
 }
 
-func newApp(s *fakeScanner, r *fakeRunner) *app.App { return app.New(s, r) }
+// fakeGitReader stands in for git. It records the context it was called with,
+// which is how the deadline App.RepoState applies is asserted without a
+// deliberately slow subprocess.
+type fakeGitReader struct {
+	state domain.RepoState
+	err   error
+
+	gotDir      string
+	gotDeadline time.Time
+	gotHasDL    bool
+	calls       int
+}
+
+func (f *fakeGitReader) State(ctx context.Context, dir string) (domain.RepoState, error) {
+	f.calls++
+	f.gotDir = dir
+	f.gotDeadline, f.gotHasDL = ctx.Deadline()
+	return f.state, f.err
+}
+
+func newApp(s *fakeScanner, r *fakeRunner) *app.App { return app.New(s, r, &fakeGitReader{}) }
+
+func newAppWithGit(s *fakeScanner, r *fakeRunner, g *fakeGitReader) *app.App {
+	return app.New(s, r, g)
+}
+
+// TestRepoStateBoundsTheRead checks the read runs under a deadline, and one
+// that is neither absent nor unreasonably far out. ADR-M003 requires captured
+// reads to be bounded; an unbounded read is a hung TUI.
+func TestRepoStateBoundsTheRead(t *testing.T) {
+	git := &fakeGitReader{state: domain.RepoState{Head: domain.HeadOnBranch, Branch: "main"}}
+	proj := domain.Project{Name: "alpha", Path: "/w/alpha"}
+
+	before := time.Now()
+	got, err := newAppWithGit(&fakeScanner{}, &fakeRunner{}, git).RepoState(context.Background(), proj)
+	if err != nil {
+		t.Fatalf("RepoState: %v", err)
+	}
+
+	if !git.gotHasDL {
+		t.Fatal("RepoState called the port with no deadline; a captured read must be bounded")
+	}
+	if budget := git.gotDeadline.Sub(before); budget <= 0 || budget > 10*time.Second {
+		t.Errorf("deadline budget = %v, want a positive budget no larger than a few seconds", budget)
+	}
+
+	// Resolved against the project's path, which is what git's upward
+	// discovery then resolves to the containing repository.
+	if git.gotDir != proj.Path {
+		t.Errorf("read ran against %q, want the project path %q", git.gotDir, proj.Path)
+	}
+	if got.Branch != "main" {
+		t.Errorf("Branch = %q, want the port's answer passed through", got.Branch)
+	}
+}
+
+// TestRepoStatePassesErrorsThrough checks the absence sentinel survives the use
+// case, so the UI can tell "no repository here" from "the read failed" with
+// errors.Is rather than by string-matching.
+func TestRepoStatePassesErrorsThrough(t *testing.T) {
+	git := &fakeGitReader{err: app.ErrNotARepository}
+	_, err := newAppWithGit(&fakeScanner{}, &fakeRunner{}, git).RepoState(
+		context.Background(), domain.Project{Path: "/w/plain"})
+
+	if !errors.Is(err, app.ErrNotARepository) {
+		t.Errorf("RepoState err = %v, want it to wrap app.ErrNotARepository", err)
+	}
+}
+
+// TestDiscoverProjectsReadsNoGitState pins the lazy-read decision at the layer
+// that would otherwise make it expensive: discovery walks the whole workspace,
+// and if it read git state per project, thirty projects would mean ninety
+// subprocesses before the TUI opened.
+func TestDiscoverProjectsReadsNoGitState(t *testing.T) {
+	git := &fakeGitReader{}
+	scanner := &fakeScanner{projects: []domain.Project{
+		{Name: "alpha", Path: "/w/alpha"},
+		{Name: "bravo", Path: "/w/bravo"},
+	}}
+
+	if _, err := newAppWithGit(scanner, &fakeRunner{}, git).DiscoverProjects(context.Background(), "/w"); err != nil {
+		t.Fatalf("DiscoverProjects: %v", err)
+	}
+
+	if git.calls != 0 {
+		t.Errorf("DiscoverProjects issued %d git reads, want 0 — reads are lazy on drill-in", git.calls)
+	}
+}
 
 // TestDiscoverProjectsComposesAndSorts checks that DiscoverProjects fills each
 // project's targets from the runner and returns the projects in

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -66,6 +66,74 @@ type Target struct {
 	Prerequisites []string
 }
 
+// Head is how a RepoState's HEAD resolved.
+//
+// It exists because `git rev-parse --abbrev-ref HEAD` prints the literal
+// string "HEAD" for both a detached head and a repository with no commits
+// yet — only the exit code separates them. Encoding either as a branch named
+// "HEAD" would be indistinguishable from a real branch, so the state is
+// carried as a discriminator rather than inferred from the branch name.
+//
+// The zero value is HeadUnknown, so a RepoState no read has filled in reads
+// as unknown rather than as a clean repository on an empty-named branch. That
+// is the "absence of a marker must not read as clean" rule enforced by the
+// zero value rather than by every caller remembering it — the same discipline
+// PhonyStatus applies.
+type Head int
+
+const (
+	// HeadUnknown means no read has resolved this repository's HEAD.
+	HeadUnknown Head = iota
+	// HeadOnBranch means HEAD is on a branch, whose name is in Branch.
+	HeadOnBranch
+	// HeadDetached means HEAD points at a commit, not a branch.
+	HeadDetached
+	// HeadUnborn means the repository has no commits yet. Per the MkX Domain
+	// Model this is a normal state, not an error: a freshly `git init`-ed
+	// project must render without a marker that reads as failure.
+	HeadUnborn
+)
+
+// String renders the head state for display and diagnostics.
+func (h Head) String() string {
+	switch h {
+	case HeadOnBranch:
+		return "on branch"
+	case HeadDetached:
+		return "detached"
+	case HeadUnborn:
+		return "unborn"
+	default:
+		return "unknown"
+	}
+}
+
+// RepoState is a Project's git state, resolved against the repository
+// containing the Project — which may sit above the Project's directory —
+// never against the Project directory in isolation.
+//
+// It is optional per Project: a Project outside any git repository has none,
+// and that is not an error condition. Per ADR-M003 it is read state, never
+// assumed current across a terminal handover.
+type RepoState struct {
+	// Head is how HEAD resolved. Consumers branch on this, never on Branch
+	// being empty.
+	Head Head
+
+	// Branch is the branch name, and is set only when Head is HeadOnBranch.
+	// It never holds the literal "HEAD" and never holds a display marker —
+	// markers are the UI's business.
+	Branch string
+
+	// Dirty is whether the working tree has any uncommitted change:
+	// modified, staged, or untracked.
+	Dirty bool
+
+	// Branches is the repository's local branches, for selection. It is empty
+	// for a repository with no commits yet.
+	Branches []string
+}
+
 // Command describes a subprocess to run with full terminal handover.
 //
 // Per ADR-M001 and ADR-M003, app use cases decide what to run and return a

--- a/internal/ui/tui/exec.go
+++ b/internal/ui/tui/exec.go
@@ -64,8 +64,25 @@ func (c *commandExec) SetStdin(io.Reader)  { /* handled in Run */ }
 func (c *commandExec) SetStdout(io.Writer) { /* handled in Run */ }
 func (c *commandExec) SetStderr(io.Writer) { /* handled in Run */ }
 
+// handoverDone wraps the message every tea.Exec handover produces.
+//
+// Update keys RepoState invalidation on this one type rather than on each
+// handover's own message, so a handover added later invalidates automatically
+// with nothing to remember at the call site. ADR-M003 says RepoState is
+// invalidated by *every* handover, and a rule phrased as "remember to
+// invalidate in each case" was already broken by the code that existed before
+// this type did.
+//
+// inner is nil for a handover that has no result to report; Update unwraps,
+// invalidates, and only then dispatches inner if there is one.
+//
+// handover_guard_test.go enforces that every tea.Exec callback in this package
+// constructs one of these.
+type handoverDone struct{ inner tea.Msg }
+
 // handover runs cmd with full terminal handover, then turns the finished
-// commandExec into the message the model expects back.
+// commandExec into the message the model expects back — wrapped, so the
+// invalidation in Update fires before that message is dispatched.
 func handover(cmd domain.Command, label string, status statusFunc, done func(*commandExec) tea.Msg) tea.Cmd {
 	ce := &commandExec{
 		command: cmd,
@@ -73,7 +90,7 @@ func handover(cmd domain.Command, label string, status statusFunc, done func(*co
 		status:  status,
 		start:   time.Now(),
 	}
-	return tea.Exec(ce, func(error) tea.Msg { return done(ce) })
+	return tea.Exec(ce, func(error) tea.Msg { return handoverDone{inner: done(ce)} })
 }
 
 // targetStatus reports a Make target's exit code and how long it took.

--- a/internal/ui/tui/filter_test.go
+++ b/internal/ui/tui/filter_test.go
@@ -254,7 +254,7 @@ func (r recordingRunner) TargetCommand(_ context.Context, dir, name string) doma
 func TestEnterRunsTheFilteredTargetNotTheUnfilteredOne(t *testing.T) {
 	var ran string
 	m := filterModel()
-	m.app = app.New(fakeScanner{}, recordingRunner{ran: &ran})
+	m.app = app.New(fakeScanner{}, recordingRunner{ran: &ran}, fakeGitReader{})
 	m.filter = filterState{active: false, text: "ver"} // matches only "verify"
 	m.targetCursor = 0
 

--- a/internal/ui/tui/git.go
+++ b/internal/ui/tui/git.go
@@ -1,0 +1,221 @@
+package tui
+
+import (
+	"context"
+	"errors"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/app"
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+	"github.com/Gaetan-Jaminon/mkx/internal/ui/tui/styles"
+)
+
+// Git state in the TUI: when it is read, how it is cached, and how it renders.
+//
+// Reads are lazy and happen on drill-in only — Enter opening a project's
+// target view, and nowhere else. The project list issues none and shows none.
+// That is what keeps discovery free: a workspace of thirty projects costs zero
+// git subprocesses and no added startup latency, where reading eagerly would
+// cost ninety before the TUI opened, with one hung repository delaying startup
+// by the whole timeout.
+//
+// The cost is that the project list cannot be scanned for branch or dirty
+// state; the user drills in to see it. TAE-58 asks for the state of the
+// *selected* Project, and in MkX selection is exactly what Enter sets.
+
+// gitStatus is what is known about a project's git state right now. It is
+// deliberately separate from domain.RepoState: "we have not finished asking"
+// and "there is nothing to ask about" are UI states, not repository states.
+type gitStatus int
+
+const (
+	// gitLoading is the zero value, so a freshly seeded entry is in flight by
+	// construction rather than by remembering to set the field.
+	gitLoading gitStatus = iota
+	// gitOK means the read succeeded and state is filled in.
+	gitOK
+	// gitAbsent means the project is in no git repository. Not an error.
+	gitAbsent
+	// gitUnknown means the read failed or timed out. Emphatically not clean.
+	gitUnknown
+)
+
+// gitEntry is one project's cache slot.
+type gitEntry struct {
+	// gen is the invalidation generation this entry belongs to. An entry from
+	// a superseded generation is discarded rather than displayed.
+	gen    int
+	status gitStatus
+	state  domain.RepoState
+}
+
+// gitStateMsg carries a finished read back into Update.
+type gitStateMsg struct {
+	project string
+	gen     int
+	status  gitStatus
+	state   domain.RepoState
+}
+
+// readRepoState issues one git read as a tea.Cmd.
+//
+// It is a plain tea.Cmd per the TUI Go Conventions baseline — no raw
+// goroutine, no channel — and the deadline is applied inside app.RepoState, so
+// nothing here can hang the event loop. The view is open and fully interactive
+// while it runs.
+//
+// Staleness is guarded by gen rather than by cancelling a view-scoped context.
+// That is the generation-counter deviation the baseline permits: MkX has no
+// view-scoped contexts today, and the guard closes the race that actually
+// matters here — see Model.invalidateGitState.
+func readRepoState(ctx context.Context, a *app.App, project domain.Project, gen int) tea.Cmd {
+	return func() tea.Msg {
+		state, err := a.RepoState(ctx, project)
+
+		msg := gitStateMsg{project: project.Name, gen: gen, state: state}
+		switch {
+		case err == nil:
+			msg.status = gitOK
+		case errors.Is(err, app.ErrNotARepository):
+			// An absence, per the Domain Model — never an error condition,
+			// and never surfaced as a flash.
+			msg.status = gitAbsent
+			msg.state = domain.RepoState{}
+		default:
+			// Everything else: a timeout, a cancellation, a broken .git, git
+			// missing from PATH. The state is unknown and the RepoState is
+			// dropped so no half-filled struct can reach the renderer.
+			msg.status = gitUnknown
+			msg.state = domain.RepoState{}
+		}
+		return msg
+	}
+}
+
+// ensureGitState seeds a loading entry for the project and returns the command
+// that reads it, or nil when the project's state is already cached.
+//
+// The entry is seeded synchronously so the target view's *first* render
+// already shows a marker rather than a blank that fills in a frame later.
+func (m Model) ensureGitState(project domain.Project) (Model, tea.Cmd) {
+	if entry, ok := m.gitCache[project.Name]; ok && entry.gen == m.gitGen {
+		// Free until invalidated.
+		return m, nil
+	}
+
+	m = m.setGitEntry(project.Name, gitEntry{gen: m.gitGen, status: gitLoading})
+	return m, readRepoState(m.rootCtx, m.app, project, m.gitGen)
+}
+
+// setGitEntry returns a Model whose cache has the entry set, without mutating
+// the receiver's map.
+//
+// Model is a value type per the TUI Go Conventions baseline, and a map field
+// is the one thing that quietly breaks that: mutating it in place writes
+// through every copy of the Model that ever shared it. Copying keeps the value
+// semantics real, and at workspace scale the copy is free.
+func (m Model) setGitEntry(name string, entry gitEntry) Model {
+	next := make(map[string]gitEntry, len(m.gitCache)+1)
+	for k, v := range m.gitCache {
+		next[k] = v
+	}
+	next[name] = entry
+	m.gitCache = next
+	return m
+}
+
+// invalidateGitState drops every cached RepoState and moves to a new
+// generation. ADR-M003: RepoState is invalidated by every handover.
+//
+// The whole cache is cleared, not the handed-over project's entry. A Make
+// recipe can cd anywhere and touch any repository, so a per-project clear is
+// false precision. Over-invalidating costs one sub-second read on the next
+// drill-in; under-invalidating is the silently-wrong-status bug this issue
+// exists to prevent.
+//
+// Bumping the generation is what closes the race the clear alone leaves open:
+// a read already in flight for project A when the handover starts can land
+// afterwards and repopulate the cache with pre-handover data — ADR-M003's
+// exact failure mode, reintroduced inside the machinery meant to prevent it.
+// A gitStateMsg whose gen no longer matches is discarded.
+func (m Model) invalidateGitState() Model {
+	m.gitCache = nil
+	m.gitGen++
+	return m
+}
+
+// applyGitState folds a finished read into the cache, discarding one that a
+// handover has already superseded.
+func (m Model) applyGitState(msg gitStateMsg) Model {
+	if msg.gen != m.gitGen {
+		// Silently discarded, per @UI Patterns: a stale result produces no
+		// flash, no warning, and no late-arriving render.
+		return m
+	}
+	return m.setGitEntry(msg.project, gitEntry{
+		gen:    msg.gen,
+		status: msg.status,
+		state:  msg.state,
+	})
+}
+
+// gitSegment renders the git state of the project whose target view is open.
+//
+// Every branch returns non-empty text. There is deliberately no path that
+// returns "" — including the no-entry case, which renders the same in-flight
+// marker as a seeded one. That is the first of three independent guards
+// against the AC's central hazard, absence reading as clean:
+//
+//  1. no branch here renders nothing,
+//  2. "clean" is spelled out rather than being the absence of a dirty marker,
+//  3. domain.RepoState's zero value is HeadUnknown, so even a state that
+//     reached this function unfilled reads as unknown rather than as a clean
+//     repository on a nameless branch.
+//
+// Precedence when several facts overlap: absent, then no-commits, then
+// unknown, then detached, then dirty, then clean. Detached outranks dirty
+// because dirty is meaningless context before knowing you are not on a branch.
+func (m Model) gitSegment(projectName string) string {
+	entry, ok := m.gitCache[projectName]
+	if !ok || entry.status == gitLoading {
+		return styles.GitPending.Render("…")
+	}
+
+	switch entry.status {
+	case gitAbsent:
+		return styles.GitPending.Render("no repo")
+	case gitUnknown:
+		// Red: a read that failed is a failure, and must not be mistakable
+		// for the dimmed "there is simply no repository here".
+		return styles.GitUnknown.Render("git unknown")
+	}
+
+	switch entry.state.Head {
+	case domain.HeadUnborn:
+		// A repository with no commits yet is a normal state per the Domain
+		// Model, so it is dimmed like absence rather than red like failure.
+		return styles.GitPending.Render("no commits")
+	case domain.HeadDetached:
+		return styles.GitAttention.Render("detached " + dirtyMarker(entry.state.Dirty))
+	case domain.HeadOnBranch:
+		if entry.state.Dirty {
+			return styles.GitAttention.Render(entry.state.Branch + " ● dirty")
+		}
+		return styles.GitClean.Render(entry.state.Branch + " ✓ clean")
+	}
+
+	// domain.HeadUnknown with a gitOK status is not a state the adapter
+	// produces — classifyHead never reports present with an unknown head. If
+	// it ever did, this must read as unknown, never as clean.
+	return styles.GitUnknown.Render("git unknown")
+}
+
+// dirtyMarker renders the dirty flag on its own, for the detached case where
+// the branch name is replaced rather than prefixed.
+func dirtyMarker(dirty bool) string {
+	if dirty {
+		return "● dirty"
+	}
+	return "✓ clean"
+}

--- a/internal/ui/tui/git_test.go
+++ b/internal/ui/tui/git_test.go
@@ -1,0 +1,500 @@
+package tui
+
+// Runtime tests for the git display and the cache behind it. Nothing here
+// spawns git: the App is wired with fakeGitReader, so every state below is a
+// literal the test chose.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/app"
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+	"github.com/Gaetan-Jaminon/mkx/internal/ui/tui/styles"
+)
+
+// gitModel is a Model on the target list of "alpha", with the git cache in
+// whatever state the caller passes. A nil entry pointer leaves the cache
+// empty, which is the never-asked state.
+func gitModel(entry *gitEntry) Model {
+	m := testModel()
+	if entry != nil {
+		m = m.setGitEntry("alpha", *entry)
+	}
+	return m
+}
+
+func okEntry(state domain.RepoState) *gitEntry {
+	return &gitEntry{status: gitOK, state: state}
+}
+
+// TestGitSegmentRendersEveryState is the AC's core display check: unknown,
+// absent and clean must be distinguishable from each other, and the absence of
+// a marker must never read as clean.
+func TestGitSegmentRendersEveryState(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry *gitEntry
+		want  string
+	}{
+		{name: "never asked", entry: nil, want: "…"},
+		{name: "loading", entry: &gitEntry{status: gitLoading}, want: "…"},
+		{name: "absent", entry: &gitEntry{status: gitAbsent}, want: "no repo"},
+		{name: "unknown", entry: &gitEntry{status: gitUnknown}, want: "git unknown"},
+		{
+			name:  "no commits yet",
+			entry: okEntry(domain.RepoState{Head: domain.HeadUnborn}),
+			want:  "no commits",
+		},
+		{
+			name:  "on a branch, clean",
+			entry: okEntry(domain.RepoState{Head: domain.HeadOnBranch, Branch: "main"}),
+			want:  "main ✓ clean",
+		},
+		{
+			name:  "on a branch, dirty",
+			entry: okEntry(domain.RepoState{Head: domain.HeadOnBranch, Branch: "main", Dirty: true}),
+			want:  "main ● dirty",
+		},
+		{
+			name:  "detached, clean",
+			entry: okEntry(domain.RepoState{Head: domain.HeadDetached}),
+			want:  "detached ✓ clean",
+		},
+		{
+			name:  "detached, dirty",
+			entry: okEntry(domain.RepoState{Head: domain.HeadDetached, Dirty: true}),
+			want:  "detached ● dirty",
+		},
+		{
+			// Not a state the adapter produces — classifyHead never reports a
+			// present head as unknown. Pinned anyway, because the one thing
+			// this must never degrade to is "clean".
+			name:  "a gitOK entry with an unfilled RepoState",
+			entry: okEntry(domain.RepoState{}),
+			want:  "git unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ansi.Strip(gitModel(tt.entry).gitSegment("alpha"))
+
+			if strings.TrimSpace(got) != tt.want {
+				t.Errorf("gitSegment = %q, want %q", strings.TrimSpace(got), tt.want)
+			}
+			// Every state renders something. A blank segment is the failure
+			// mode the AC names: it reads as "nothing to report", which for a
+			// dirty or unreadable repository is a lie.
+			if strings.TrimSpace(got) == "" {
+				t.Error("gitSegment rendered blank")
+			}
+			if strings.Contains(got, "HEAD") {
+				t.Errorf("gitSegment leaked the literal HEAD: %q", got)
+			}
+		})
+	}
+}
+
+// TestGitSegmentDistinguishesUnknownAbsentAndClean checks the AC's
+// must-distinguish trio differ in wording.
+func TestGitSegmentDistinguishesUnknownAbsentAndClean(t *testing.T) {
+	rendered := map[string]string{
+		"unknown": ansi.Strip(gitModel(&gitEntry{status: gitUnknown}).gitSegment("alpha")),
+		"absent":  ansi.Strip(gitModel(&gitEntry{status: gitAbsent}).gitSegment("alpha")),
+		"clean": ansi.Strip(gitModel(
+			okEntry(domain.RepoState{Head: domain.HeadOnBranch, Branch: "main"})).gitSegment("alpha")),
+	}
+
+	for aName, a := range rendered {
+		for bName, b := range rendered {
+			if aName < bName && a == b {
+				t.Errorf("%s and %s render the same text %q", aName, bName, a)
+			}
+		}
+	}
+}
+
+// TestGitStylesAreThreeDifferentColours is the other half of "distinguishable":
+// three different words in one colour would pass the test above and still fail
+// the user at a glance.
+//
+// It asserts on the style declarations rather than on rendered output, and the
+// reason is a real limitation rather than a preference: lipgloss detects no
+// TTY under `go test` and strips every escape, so a rendered segment carries no
+// colour to compare. What this cannot catch is gitSegment routing a state to
+// the wrong style — that routing is covered state-by-state by the text
+// assertions in TestGitSegmentRendersEveryState, and by the visual step of the
+// PR's verification handoff.
+func TestGitStylesAreThreeDifferentColours(t *testing.T) {
+	colours := map[string]string{
+		"unknown": fmt.Sprint(styles.GitUnknown.GetForeground()),
+		"absent":  fmt.Sprint(styles.GitPending.GetForeground()),
+		"clean":   fmt.Sprint(styles.GitClean.GetForeground()),
+		"dirty":   fmt.Sprint(styles.GitAttention.GetForeground()),
+	}
+
+	for aName, a := range colours {
+		for bName, b := range colours {
+			if aName < bName && a == b {
+				t.Errorf("%s and %s share the foreground colour %s", aName, bName, a)
+			}
+		}
+	}
+
+	// The git segment must not reuse the header title's colour: they sit
+	// adjacent in the top bar and would visually merge.
+	title := fmt.Sprint(styles.Header.GetForeground())
+	for name, c := range colours {
+		if c == title {
+			t.Errorf("the %s segment reuses the header title's colour %s", name, c)
+		}
+	}
+}
+
+// TestProjectListShowsNoGitState pins the lazy-read decision at the surface
+// where it is visible. The project list issues no reads, so it must show no
+// git state — including for a project whose state happens to be cached from an
+// earlier drill-in.
+func TestProjectListShowsNoGitState(t *testing.T) {
+	m := gitModel(okEntry(domain.RepoState{Head: domain.HeadOnBranch, Branch: "main", Dirty: true}))
+	m.view = viewProjects
+
+	header := ansi.Strip(strings.SplitN(m.renderProjectList(), "\n", 2)[0])
+
+	for _, leaked := range []string{"main", "dirty", "clean", "no repo", "git unknown", "…"} {
+		if strings.Contains(header, leaked) {
+			t.Errorf("the project header leaked git state %q: %q", leaked, header)
+		}
+	}
+	if !strings.Contains(header, "mkx › Projects") {
+		t.Errorf("the project header lost its title: %q", header)
+	}
+}
+
+// TestTargetHeaderShowsGitState is the positive half: the same state that must
+// stay out of the project list must appear in the target view.
+func TestTargetHeaderShowsGitState(t *testing.T) {
+	m := gitModel(okEntry(domain.RepoState{Head: domain.HeadOnBranch, Branch: "main", Dirty: true}))
+
+	header := ansi.Strip(strings.SplitN(m.renderTargetList(), "\n", 2)[0])
+
+	if !strings.Contains(header, "main ● dirty") {
+		t.Errorf("the target header is missing the git segment: %q", header)
+	}
+	if !strings.Contains(header, "mkx › alpha") {
+		t.Errorf("the target header lost its title: %q", header)
+	}
+	if !strings.Contains(header, "2/2") {
+		t.Errorf("the git segment displaced the position counter: %q", header)
+	}
+}
+
+// TestDrillInSeedsLoadingAndIssuesTheRead covers the read timing: Enter is the
+// only thing that starts a read, the entry is seeded synchronously so the
+// first render carries a marker, and the read itself is a command rather than
+// inline work.
+func TestDrillInSeedsLoadingAndIssuesTheRead(t *testing.T) {
+	m := testModel()
+	m.view = viewProjects
+	m.projectCursor = 0
+
+	after, cmd := projectKeymap().dispatch("enter")(m, "enter")
+
+	if after.view != viewTargets {
+		t.Fatal("Enter did not open the target view")
+	}
+	entry, ok := after.gitCache["alpha"]
+	if !ok {
+		t.Fatal("Enter seeded no cache entry; the first render would have nothing to show")
+	}
+	if entry.status != gitLoading {
+		t.Errorf("seeded entry status = %v, want gitLoading", entry.status)
+	}
+	if cmd == nil {
+		t.Fatal("Enter issued no read command")
+	}
+
+	// The synchronous seed is what makes the very first render non-blank.
+	if seg := strings.TrimSpace(ansi.Strip(after.gitSegment("alpha"))); seg != "…" {
+		t.Errorf("first render's segment = %q, want the in-flight marker", seg)
+	}
+}
+
+// TestDrillInIsFreeOnACacheHit checks re-entering a project issues no second
+// read while the cache is still valid.
+func TestDrillInIsFreeOnACacheHit(t *testing.T) {
+	m := gitModel(okEntry(domain.RepoState{Head: domain.HeadOnBranch, Branch: "main"}))
+	m.view = viewProjects
+
+	_, cmd := projectKeymap().dispatch("enter")(m, "enter")
+	if cmd != nil {
+		t.Error("re-entering a cached project issued a read")
+	}
+}
+
+// TestProjectListIssuesNoReads is the negative half of the read-timing
+// decision, asserted against the reader itself rather than against the render:
+// navigating the project list must spawn nothing.
+func TestProjectListIssuesNoReads(t *testing.T) {
+	calls := 0
+	m := testModel()
+	m.app = app.New(fakeScanner{}, fakeRunner{}, fakeGitReader{calls: &calls})
+	m.view = viewProjects
+
+	for _, key := range []string{"down", "up", "j", "k"} {
+		if h := projectKeymap().dispatch(key); h != nil {
+			m, _ = h(m, key)
+		}
+	}
+
+	if calls != 0 {
+		t.Errorf("navigating the project list issued %d git reads, want 0", calls)
+	}
+}
+
+// TestReadRepoStateClassifiesOutcomes checks the port's three answers map onto
+// the three cache statuses, and that neither failure mode carries a
+// half-filled RepoState into the cache.
+func TestReadRepoStateClassifiesOutcomes(t *testing.T) {
+	tests := []struct {
+		name       string
+		state      domain.RepoState
+		err        error
+		wantStatus gitStatus
+	}{
+		{
+			name:       "success",
+			state:      domain.RepoState{Head: domain.HeadOnBranch, Branch: "main", Dirty: true},
+			wantStatus: gitOK,
+		},
+		{
+			name:       "not a repository is an absence, not a failure",
+			err:        app.ErrNotARepository,
+			wantStatus: gitAbsent,
+		},
+		{
+			name:       "a wrapped sentinel is still an absence",
+			err:        errWrapping(app.ErrNotARepository),
+			wantStatus: gitAbsent,
+		},
+		{
+			name:       "timeout is unknown",
+			err:        context.DeadlineExceeded,
+			wantStatus: gitUnknown,
+		},
+		{
+			// The specific hazard: a failed read that still handed back a
+			// zero RepoState must not be cached as one, or Dirty:false would
+			// be indistinguishable from a clean tree.
+			name:       "a failed read carrying a zero state is unknown, not clean",
+			err:        errors.New("git status: exit 128"),
+			wantStatus: gitUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := app.New(fakeScanner{}, fakeRunner{}, fakeGitReader{state: tt.state, err: tt.err})
+			proj := domain.Project{Name: "alpha", Path: "/w/alpha"}
+
+			msg, ok := readRepoState(context.Background(), a, proj, 7)().(gitStateMsg)
+			if !ok {
+				t.Fatal("readRepoState did not produce a gitStateMsg")
+			}
+
+			if msg.status != tt.wantStatus {
+				t.Errorf("status = %v, want %v", msg.status, tt.wantStatus)
+			}
+			if msg.project != "alpha" {
+				t.Errorf("project = %q, want alpha", msg.project)
+			}
+			if msg.gen != 7 {
+				t.Errorf("gen = %d, want the generation the read was issued in", msg.gen)
+			}
+			zero := msg.state.Head == domain.HeadUnknown &&
+				msg.state.Branch == "" && !msg.state.Dirty && len(msg.state.Branches) == 0
+			if tt.wantStatus != gitOK && !zero {
+				t.Errorf("a %v result carried a RepoState: %+v", tt.wantStatus, msg.state)
+			}
+		})
+	}
+}
+
+func errWrapping(err error) error { return &wrapped{err} }
+
+type wrapped struct{ err error }
+
+func (w *wrapped) Error() string { return "reading git state: " + w.err.Error() }
+func (w *wrapped) Unwrap() error { return w.err }
+
+// TestStaleReadIsDiscarded covers the race the generation counter exists for: a
+// read issued before a handover landing after it would otherwise repopulate the
+// cache with pre-handover data — ADR-M003's exact failure mode, reintroduced
+// inside the invalidation machinery.
+func TestStaleReadIsDiscarded(t *testing.T) {
+	m := testModel()
+	m.gitGen = 3
+
+	stale := gitStateMsg{
+		project: "alpha",
+		gen:     2, // issued before the last invalidation
+		status:  gitOK,
+		state:   domain.RepoState{Head: domain.HeadOnBranch, Branch: "stale-branch"},
+	}
+
+	if _, ok := m.applyGitState(stale).gitCache["alpha"]; ok {
+		t.Error("a superseded read was written to the cache")
+	}
+
+	// The current generation still lands, so the guard is discarding by age
+	// rather than discarding everything.
+	fresh := stale
+	fresh.gen = 3
+	entry, ok := m.applyGitState(fresh).gitCache["alpha"]
+	if !ok {
+		t.Fatal("a current-generation read was discarded")
+	}
+	if entry.state.Branch != "stale-branch" {
+		t.Errorf("cached branch = %q, want the read's answer", entry.state.Branch)
+	}
+}
+
+// TestHandoverInvalidatesAndReReads proves the effect rather than the
+// structure: the wrapper clears the cache, bumps the generation, re-issues a
+// read for the open view, and still dispatches its inner message.
+func TestHandoverInvalidatesAndReReads(t *testing.T) {
+	m := gitModel(okEntry(domain.RepoState{Head: domain.HeadOnBranch, Branch: "main"}))
+	genBefore := m.gitGen
+
+	updated, cmd := m.Update(handoverDone{inner: execFinishedMsg{exitCode: 0}})
+	after := updated.(Model)
+
+	if after.gitGen == genBefore {
+		t.Error("the handover did not bump the generation; a read in flight could repopulate stale state")
+	}
+	// The pre-handover entry is gone. It is replaced by a freshly seeded
+	// loading entry for the open view, never by the old one.
+	if entry, ok := after.gitCache["alpha"]; ok && entry.status != gitLoading {
+		t.Errorf("the pre-handover entry survived: %+v", entry)
+	}
+	if cmd == nil {
+		t.Error("the handover issued no re-read for the open target view")
+	}
+	// The inner message still reached its own case.
+	if after.lastRun == nil {
+		t.Error("the inner execFinishedMsg was swallowed by the unwrap")
+	}
+}
+
+// TestHandoverWithNoInnerMessageStillInvalidates covers the README viewer,
+// which has nothing to report but has still given up the terminal.
+func TestHandoverWithNoInnerMessageStillInvalidates(t *testing.T) {
+	m := gitModel(okEntry(domain.RepoState{Head: domain.HeadOnBranch, Branch: "main"}))
+	genBefore := m.gitGen
+
+	updated, cmd := m.Update(handoverDone{})
+	after := updated.(Model)
+
+	if after.gitGen == genBefore {
+		t.Error("a handover with no inner message did not invalidate")
+	}
+	if cmd == nil {
+		t.Error("no re-read was issued after the README handover")
+	}
+}
+
+// TestAnUnwrappedMessageDoesNotInvalidate is the direct demonstration of what
+// a bypass would cost, and the runtime counterpart to the AST guard: the same
+// message unwrapped leaves the stale state on screen.
+func TestAnUnwrappedMessageDoesNotInvalidate(t *testing.T) {
+	m := gitModel(okEntry(domain.RepoState{Head: domain.HeadOnBranch, Branch: "main"}))
+	genBefore := m.gitGen
+
+	updated, _ := m.Update(execFinishedMsg{exitCode: 0})
+	after := updated.(Model)
+
+	if after.gitGen != genBefore {
+		t.Error("an unwrapped message invalidated; the guard's premise no longer holds")
+	}
+	if entry := after.gitCache["alpha"]; entry.state.Branch != "main" {
+		t.Error("an unwrapped message cleared the cache")
+	}
+	if seg := ansi.Strip(after.gitSegment("alpha")); !strings.Contains(seg, "main") {
+		t.Errorf("segment after an unwrapped message = %q; this is the stale display "+
+			"handoverDone exists to prevent", seg)
+	}
+}
+
+// TestHandoverOnTheProjectListIssuesNoRead checks the re-read follows the same
+// rule as the initial one: nothing is read while the project list is up, even
+// though the invalidation still happens.
+func TestHandoverOnTheProjectListIssuesNoRead(t *testing.T) {
+	m := gitModel(okEntry(domain.RepoState{Head: domain.HeadOnBranch, Branch: "main"}))
+	m.view = viewProjects
+	genBefore := m.gitGen
+
+	updated, cmd := m.Update(handoverDone{inner: gitPullFinishedMsg{projectIndex: 0}})
+	after := updated.(Model)
+
+	if after.gitGen == genBefore {
+		t.Error("a handover from the project list did not invalidate")
+	}
+	if len(after.gitCache) != 0 {
+		t.Errorf("the cache was not cleared: %+v", after.gitCache)
+	}
+	// gitPullFinishedMsg returns tea.EnterAltScreen, so cmd is non-nil; what
+	// matters is that no read was seeded.
+	_ = cmd
+}
+
+// TestSetGitEntryDoesNotMutateTheReceiver guards the one field that would
+// quietly break Model's value semantics. A map mutated in place writes through
+// every copy that ever shared it, including the pre-handover model a test is
+// holding to compare against.
+func TestSetGitEntryDoesNotMutateTheReceiver(t *testing.T) {
+	before := gitModel(okEntry(domain.RepoState{Head: domain.HeadOnBranch, Branch: "main"}))
+
+	after := before.setGitEntry("alpha", gitEntry{status: gitUnknown})
+
+	if before.gitCache["alpha"].status != gitOK {
+		t.Error("setGitEntry mutated the receiver's cache")
+	}
+	if after.gitCache["alpha"].status != gitUnknown {
+		t.Error("setGitEntry did not apply to the returned Model")
+	}
+}
+
+// TestGitReadIsACommandNotInlineWork checks the read never runs on the update
+// path. A read done inline would block the event loop for its whole timeout on
+// a hung repository, which is exactly what the AC forbids.
+func TestGitReadIsACommandNotInlineWork(t *testing.T) {
+	calls := 0
+	m := testModel()
+	m.app = app.New(fakeScanner{}, fakeRunner{}, fakeGitReader{calls: &calls})
+	m.view = viewProjects
+
+	_, cmd := projectKeymap().dispatch("enter")(m, "enter")
+
+	if calls != 0 {
+		t.Errorf("the read ran during Update (%d calls); it must run in the tea.Cmd", calls)
+	}
+	if cmd == nil {
+		t.Fatal("no command was returned")
+	}
+
+	// It does run when the runtime executes the command.
+	var msg tea.Msg = cmd()
+	if _, ok := msg.(gitStateMsg); !ok {
+		t.Fatalf("the command produced %T, want gitStateMsg", msg)
+	}
+	if calls != 1 {
+		t.Errorf("the command issued %d reads, want 1", calls)
+	}
+}

--- a/internal/ui/tui/handover_guard_test.go
+++ b/internal/ui/tui/handover_guard_test.go
@@ -1,0 +1,300 @@
+package tui
+
+// The structural half of ADR-M003's "RepoState is invalidated by every
+// handover".
+//
+// Update invalidates on the handoverDone wrapper, which makes invalidation
+// automatic for any handover that goes *through* handover(). This guard covers
+// the ones that do not: a tea.Exec written directly, returning its own message
+// or nil, bypasses the wrapper entirely and silently keeps a stale RepoState
+// on screen. That is not hypothetical — readme.go did exactly this before
+// TAE-58, returning nil from its tea.Exec callback, so Update never saw the
+// handover at all.
+//
+// The check is static over the package's own source, in the spirit of
+// internal/app/oracle_guard_test.go: an invariant made un-forgettable rather
+// than trusted to a reviewer noticing.
+//
+// There is deliberately no file allowlist. Which files hold a tea.Exec today
+// is exactly the fact a new file makes stale, and an allowlist would let that
+// new file pass by not being on it.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// wrapperType is the type every tea.Exec callback must construct.
+const wrapperType = "handoverDone"
+
+// execViolation is one tea.Exec whose callback does not construct the wrapper.
+type execViolation struct {
+	file string
+	line int
+	why  string
+}
+
+// checkExecCallbacks reports every tea.Exec call in a parsed file whose
+// completion callback fails to construct wrapperType.
+//
+// It is factored as a pure function over an already-parsed file — rather than
+// as a test that walks the tree itself — for one reason: it can then be driven
+// from a table of synthetic sources below. A guard that has only ever been run
+// against compliant code has demonstrated nothing except that it does not
+// crash.
+func checkExecCallbacks(fset *token.FileSet, file *ast.File, name string) []execViolation {
+	var violations []execViolation
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Exec" {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok || pkg.Name != "tea" {
+			return true
+		}
+
+		line := fset.Position(call.Pos()).Line
+
+		// tea.Exec(cmd, callback) — the callback is the second argument.
+		if len(call.Args) < 2 {
+			violations = append(violations, execViolation{
+				file: name, line: line,
+				why: "tea.Exec called with no completion callback",
+			})
+			return true
+		}
+
+		if !constructsWrapper(call.Args[1]) {
+			violations = append(violations, execViolation{
+				file: name, line: line,
+				why: "the tea.Exec callback does not construct " + wrapperType,
+			})
+		}
+		return true
+	})
+
+	return violations
+}
+
+// constructsWrapper reports whether expr — a tea.Exec completion callback —
+// contains a composite literal of wrapperType anywhere in its body.
+//
+// Containment rather than "returns exactly": handoverDone{inner: done(ce)} is
+// the compliant shape in exec.go, and a callback that builds one in a local
+// before returning it is equally fine. What is being caught is a callback that
+// never mentions the wrapper at all.
+func constructsWrapper(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		if id, ok := lit.Type.(*ast.Ident); ok && id.Name == wrapperType {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// TestEveryHandoverInvalidatesRepoState is the guard proper: it scans this
+// package's real source.
+func TestEveryHandoverInvalidatesRepoState(t *testing.T) {
+	fset := token.NewFileSet()
+
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("globbing package sources: %v", err)
+	}
+
+	var violations []execViolation
+	execSites := 0
+
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		parsed, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		execSites += countExecCalls(parsed)
+		violations = append(violations, checkExecCallbacks(fset, parsed, path)...)
+	}
+
+	for _, v := range violations {
+		t.Errorf("%s:%d: %s. Per ADR-M003 every terminal handover invalidates RepoState, "+
+			"and Update keys that on %s. Route this through handover(), or return %s{} from the callback.",
+			v.file, v.line, v.why, wrapperType, wrapperType)
+	}
+
+	// Non-vacuity. A glob that matched nothing, or a tea.Exec detector that
+	// stopped detecting, would leave the loop above with nothing to complain
+	// about and report green. Two are known to exist: the shared handover() in
+	// exec.go and the README viewer in readme.go.
+	if execSites < 2 {
+		t.Errorf("found %d tea.Exec call sites, expected at least 2; "+
+			"the scan is not reaching this package's source and the guard is passing vacuously", execSites)
+	}
+}
+
+// countExecCalls counts tea.Exec calls, whatever their callbacks look like.
+func countExecCalls(file *ast.File) int {
+	n := 0
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Exec" {
+			if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "tea" {
+				n++
+			}
+		}
+		return true
+	})
+	return n
+}
+
+// TestHandoverGuardRejectsBypasses is the half that matters.
+//
+// A green run of a verification mechanism is the weakest possible evidence it
+// works — it is equally consistent with a checker that returns "fine" for
+// everything. So the checker is driven over synthetic sources that are known
+// bypasses, including the exact shape readme.go had before this issue, and
+// asserted to reject each one.
+func TestHandoverGuardRejectsBypasses(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantBad int
+	}{
+		{
+			name:    "compliant: wrapper constructed inline",
+			wantBad: 0,
+			src: `package tui
+func f() tea.Cmd {
+	return tea.Exec(ce, func(error) tea.Msg { return handoverDone{inner: done(ce)} })
+}`,
+		},
+		{
+			name:    "compliant: bare wrapper, nothing to report",
+			wantBad: 0,
+			src: `package tui
+func f() tea.Cmd {
+	return tea.Exec(&readmeExec{path: p}, func(error) tea.Msg { return handoverDone{} })
+}`,
+		},
+		{
+			name:    "compliant: wrapper built in a local first",
+			wantBad: 0,
+			src: `package tui
+func f() tea.Cmd {
+	return tea.Exec(ce, func(error) tea.Msg {
+		msg := handoverDone{inner: execFinishedMsg{}}
+		return msg
+	})
+}`,
+		},
+		{
+			// readme.go's shape before TAE-58. Update never saw this handover,
+			// so no rule expressed as "invalidate in the message's case" could
+			// ever have covered it.
+			name:    "bypass: callback returns nil",
+			wantBad: 1,
+			src: `package tui
+func f() tea.Cmd {
+	return tea.Exec(&readmeExec{path: p}, func(error) tea.Msg { return nil })
+}`,
+		},
+		{
+			name:    "bypass: callback returns an unwrapped message",
+			wantBad: 1,
+			src: `package tui
+func f() tea.Cmd {
+	return tea.Exec(ce, func(error) tea.Msg { return execFinishedMsg{exitCode: 0} })
+}`,
+		},
+		{
+			// The subtlest one: a message type whose *name* resembles the
+			// wrapper is not the wrapper.
+			name:    "bypass: a differently-named composite literal",
+			wantBad: 1,
+			src: `package tui
+func f() tea.Cmd {
+	return tea.Exec(ce, func(error) tea.Msg { return handoverFinished{} })
+}`,
+		},
+		{
+			name:    "bypass: two unwrapped handovers are both reported",
+			wantBad: 2,
+			src: `package tui
+func f() tea.Cmd {
+	if x {
+		return tea.Exec(a, func(error) tea.Msg { return nil })
+	}
+	return tea.Exec(b, func(error) tea.Msg { return gitPullFinishedMsg{} })
+}`,
+		},
+		{
+			name:    "bypass: one compliant and one not, only the bad one is reported",
+			wantBad: 1,
+			src: `package tui
+func f() tea.Cmd {
+	if x {
+		return tea.Exec(a, func(error) tea.Msg { return handoverDone{} })
+	}
+	return tea.Exec(b, func(error) tea.Msg { return nil })
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			parsed, err := parser.ParseFile(fset, tt.name+".go", tt.src, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parsing the synthetic source: %v", err)
+			}
+
+			got := checkExecCallbacks(fset, parsed, tt.name+".go")
+			if len(got) != tt.wantBad {
+				t.Fatalf("checkExecCallbacks reported %d violations, want %d: %+v", len(got), tt.wantBad, got)
+			}
+		})
+	}
+}
+
+// TestHandoverGuardSeesTheRealCallSites pins the detector against the actual
+// files, so a refactor that renamed or moved the handovers cannot leave the
+// guard scanning a package with nothing in it and still reporting green.
+func TestHandoverGuardSeesTheRealCallSites(t *testing.T) {
+	fset := token.NewFileSet()
+
+	for _, path := range []string{"exec.go", "readme.go"} {
+		parsed, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		if n := countExecCalls(parsed); n == 0 {
+			t.Errorf("%s holds no tea.Exec call; if the handover moved, move this expectation with it "+
+				"rather than deleting it", path)
+		}
+	}
+}

--- a/internal/ui/tui/keymap_views.go
+++ b/internal/ui/tui/keymap_views.go
@@ -33,14 +33,24 @@ func projectKeymap() keymap {
 		{keys: []string{"enter"}, display: "Enter", label: "Targets",
 			help: "Open the project's target list", inBar: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
-				if len(m.projects) > 0 {
-					m.selectedProject = m.projectCursor
-					m.targetCursor = 0
-					// A filter never survives leaving the view it filtered.
-					m.filter = filterState{}
-					m.view = viewTargets
+				if len(m.projects) == 0 {
+					return m, nil
 				}
-				return m, nil
+				m.selectedProject = m.projectCursor
+				m.targetCursor = 0
+				// A filter never survives leaving the view it filtered.
+				m.filter = filterState{}
+				m.view = viewTargets
+
+				// The only place a git read is issued by a key press. Drill-in
+				// is the moment "the selected Project" becomes meaningful in
+				// MkX — selectedProject is set here and nowhere else — and
+				// reading here rather than in the project list is what keeps a
+				// thirty-project workspace free until the user asks. The entry
+				// is seeded synchronously so the first render of the view
+				// below already carries a marker; the read itself runs off the
+				// event loop and never blocks it.
+				return m.ensureGitState(m.projects[m.selectedProject])
 			}},
 		{keys: []string{"g"}, display: "g", label: "Pull",
 			help: "Git pull and re-read targets", inBar: true,

--- a/internal/ui/tui/modal_help_test.go
+++ b/internal/ui/tui/modal_help_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
 )
 
 // helpView opens the help overlay over the named view and returns the full
@@ -15,6 +17,16 @@ func helpView(t *testing.T, v view) string {
 
 	m := testModel()
 	m.view = v
+
+	// A resolved git state, so the header carries a settled segment rather
+	// than the in-flight "…". TestHelpFitsAtEightyByTwentyFour uses "…" as its
+	// truncation sentinel, and a header that is merely still loading is not a
+	// truncated help row. Seeding here keeps that guard checking exactly what
+	// it was written to check.
+	m = m.setGitEntry(m.projects[m.selectedProject].Name, gitEntry{
+		status: gitOK,
+		state:  domain.RepoState{Head: domain.HeadOnBranch, Branch: "main"},
+	})
 
 	opened, _ := m.viewKeymap().dispatch("?")(m, "?")
 	if !opened.modal.active {

--- a/internal/ui/tui/model.go
+++ b/internal/ui/tui/model.go
@@ -50,6 +50,14 @@ type Model struct {
 	// filter mode over the target list; the zero value is no filter
 	filter filterState
 
+	// git state, keyed by project name and populated lazily on drill-in.
+	// Map membership is what distinguishes "never asked" from every outcome,
+	// so no separate requested flag exists. See git.go.
+	gitCache map[string]gitEntry
+	// gitGen is the invalidation generation. It is bumped by every handover;
+	// a read that lands carrying an older one is discarded.
+	gitGen int
+
 	// last run
 	lastRun *runResult
 
@@ -82,7 +90,56 @@ func (m Model) Init() tea.Cmd {
 	return nil
 }
 
+// Update is two stages: the handover unwrap, then the message dispatch.
+//
+// The unwrap is what makes ADR-M003's "RepoState is invalidated by every
+// handover" structural rather than a rule each call site has to remember.
+// Every tea.Exec in this package returns handoverDone (enforced by
+// handover_guard_test.go), so invalidation happens here, once, before the
+// wrapped message reaches its own case — and the cases below are untouched by
+// it. A handover added later inherits this with nothing to write.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var afterHandover tea.Cmd
+
+	if done, ok := msg.(handoverDone); ok {
+		m = m.invalidateGitState()
+		// Re-read immediately when a target view is open, so returning from a
+		// handover shows a brief in-flight marker and then the current state,
+		// rather than a state the handover may have made a lie.
+		m, afterHandover = m.refreshOpenGitState()
+
+		if done.inner == nil {
+			// A handover with nothing to report — the README viewer. It still
+			// invalidated; there is just no inner message to dispatch.
+			return m, afterHandover
+		}
+		msg = done.inner
+	}
+
+	model, cmd := m.dispatch(msg)
+	if afterHandover != nil {
+		return model, tea.Batch(cmd, afterHandover)
+	}
+	return model, cmd
+}
+
+// refreshOpenGitState re-issues the git read for the project currently on
+// screen, if any. Nothing is read when the project list is up: that view shows
+// no git state and must not start issuing reads through the back door.
+func (m Model) refreshOpenGitState() (Model, tea.Cmd) {
+	if m.view != viewTargets {
+		return m, nil
+	}
+	proj, ok := m.currentProject()
+	if !ok {
+		return m, nil
+	}
+	return m.ensureGitState(proj)
+}
+
+// dispatch is Update's message switch, reached with any handover already
+// unwrapped and its invalidation already applied.
+func (m Model) dispatch(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -96,6 +153,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case runFailedMsg:
 		m.flash = msg.err.Error()
 		return m, nil
+
+	case gitStateMsg:
+		// A failed read produces no flash and no error banner. Per ADR-M003 a
+		// failed or absent read is not an error condition — it is a state, and
+		// the header is where it is shown.
+		return m.applyGitState(msg), nil
 
 	case gitPullFinishedMsg:
 		targets, _ := m.app.RefreshTargets(m.rootCtx, m.projects[msg.projectIndex])
@@ -138,7 +201,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // Tier 2 sits after tier 1's unconditional return, so with a modal up the
 // filter never sees a key. When filter mode is inactive it is a no-op and the
 // path is what it was before filtering existed.
-func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	key := msg.String()
 
 	if m.modal.active {
@@ -267,9 +330,15 @@ func (m Model) renderHintBar(k keymap) string {
 	return styles.HintBar.Width(m.width).Render(bar)
 }
 
-func (m Model) renderHeader(section string, current, total int) string {
+// renderHeader renders the top bar: the title on the left, the position
+// counter hard right, and an optional already-styled middle segment beside the
+// title.
+//
+// middle is "" for the project list, which shows no git state — a test pins
+// that view's exact header output so the git segment cannot drift into it.
+func (m Model) renderHeader(section, middle string, current, total int) string {
 	title := "mkx › " + section
-	left := styles.Header.Render(title)
+	left := styles.Header.Render(title) + middle
 	count := styles.HeaderCount.Render(fmt.Sprintf("%d/%d", current, total))
 	gap := m.width - lipgloss.Width(left) - lipgloss.Width(count)
 	if gap < 0 {
@@ -312,7 +381,9 @@ func (m Model) renderProjectList() string {
 	iw := w - 2 // inner width (excluding │ borders)
 
 	// header
-	s := m.renderHeader("Projects", m.projectCursor+1, len(m.projects)) + "\n"
+	// No middle segment: the project list shows no git state, because it
+	// issues no git reads. See git.go for why that trade is deliberate.
+	s := m.renderHeader("Projects", "", m.projectCursor+1, len(m.projects)) + "\n"
 	s += styles.Border.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
 
 	if len(m.projects) == 0 {
@@ -409,7 +480,7 @@ func (m Model) renderTargetList() string {
 	iw := w - 2
 
 	// header
-	s := m.renderHeader(proj.Name, m.targetCursor+1, len(targets)) + "\n"
+	s := m.renderHeader(proj.Name, m.gitSegment(proj.Name), m.targetCursor+1, len(targets)) + "\n"
 	s += styles.Border.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
 
 	// The filter bar renders on the text, not on the mode: after Enter closes

--- a/internal/ui/tui/model_test.go
+++ b/internal/ui/tui/model_test.go
@@ -29,11 +29,29 @@ func (fakeRunner) TargetCommand(_ context.Context, dir, name string) domain.Comm
 	return domain.Command{Argv: []string{"make", name}, WorkDir: dir}
 }
 
+// fakeGitReader stands in for git. Every field is a literal the test sets, so
+// no test in this package spawns a git process or needs a repository on disk.
+type fakeGitReader struct {
+	state domain.RepoState
+	err   error
+
+	// calls counts reads, which is how "the project list issues none" and
+	// "re-entering a cached project is free" are asserted.
+	calls *int
+}
+
+func (f fakeGitReader) State(context.Context, string) (domain.RepoState, error) {
+	if f.calls != nil {
+		*f.calls++
+	}
+	return f.state, f.err
+}
+
 // testModel is a Model on the target list of a project with two targets,
 // cursor parked on the second.
 func testModel() Model {
 	return Model{
-		app:     app.New(fakeScanner{readme: "/tmp/README.md"}, fakeRunner{}),
+		app:     app.New(fakeScanner{readme: "/tmp/README.md"}, fakeRunner{}, fakeGitReader{}),
 		rootCtx: context.Background(),
 		projects: []domain.Project{{
 			Name: "alpha",

--- a/internal/ui/tui/readme.go
+++ b/internal/ui/tui/readme.go
@@ -58,13 +58,25 @@ func (r *readmeExec) SetStderr(io.Writer) {}
 
 // viewReadme returns a command to display the README at path, or a
 // not-found message when the project has none.
+//
+// It returns handoverDone rather than nil. Viewing a README cannot change a
+// branch or dirty a tree, so an exemption here is arguable — but an exemption
+// has to be defended and enforced forever, and enforcing it is the expensive
+// part. Routing this through costs one redundant sub-second re-read and buys
+// ADR-M003's rule with zero exceptions, which is what it literally says.
+//
+// The previous nil return is also what made the old "invalidate in each
+// handover's case" phrasing unenforceable: Update never saw this handover at
+// all.
 func viewReadme(path string) tea.Cmd {
 	if path == "" {
+		// Not a handover — no tea.Exec, no terminal given up, nothing that
+		// could have changed the repository.
 		return func() tea.Msg {
 			return readmeNotFoundMsg{}
 		}
 	}
 	return tea.Exec(&readmeExec{path: path}, func(error) tea.Msg {
-		return nil
+		return handoverDone{}
 	})
 }

--- a/internal/ui/tui/styles/styles.go
+++ b/internal/ui/tui/styles/styles.go
@@ -65,6 +65,48 @@ var (
 	FilterBar = lipgloss.NewStyle().
 			Foreground(colorCyan)
 
+	// The git segment in the target view's header. Four styles for seven
+	// states, and the split is deliberate: @UI Patterns' colour conventions
+	// give red to failure, green to success, yellow to attention-not-failure,
+	// and dimmed to the merely muted. TAE-58 requires unknown, absent and
+	// clean to be distinguishable from each other, so those three get three
+	// different colours rather than three different words in one colour.
+	//
+	// All four carry the header's background, so the segment reads as part of
+	// the top bar rather than as text floating over it.
+	//
+	// Blue is deliberately unused here — it belongs to the adjacent header
+	// title, and reusing it would visually merge the two.
+
+	// GitClean is a repository with no uncommitted changes.
+	GitClean = lipgloss.NewStyle().
+			Foreground(colorGreen).
+			Background(lipgloss.Color("235")).
+			Padding(0, 1)
+
+	// GitAttention is a repository wanting a second look but not in error —
+	// an uncommitted change, or a detached head.
+	GitAttention = lipgloss.NewStyle().
+			Foreground(colorYellow).
+			Background(lipgloss.Color("235")).
+			Padding(0, 1)
+
+	// GitUnknown is a read that failed or timed out. Red, because a failed
+	// read is a failure — and because it must not be mistakable for the
+	// dimmed "there is no repository here", which is not.
+	GitUnknown = lipgloss.NewStyle().
+			Foreground(colorRed).
+			Background(lipgloss.Color("235")).
+			Padding(0, 1)
+
+	// GitPending is the muted set: a read in flight, a project in no
+	// repository, and a repository with no commits yet. None of the three is
+	// an error condition, and none is rendered as one.
+	GitPending = lipgloss.NewStyle().
+			Foreground(colorDimmed).
+			Background(lipgloss.Color("235")).
+			Padding(0, 1)
+
 	// HintKey is the key name in the bottom hint bar.
 	HintKey = lipgloss.NewStyle().
 		Foreground(colorBlue).

--- a/scripts/demo-git.sh
+++ b/scripts/demo-git.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Builds a throwaway workspace exercising every git state MkX can display, so
+# the visual half of TAE-58's verification can be run by eye in one place.
+#
+# It is built under a temp directory rather than inside this repository for one
+# specific reason: the "no repo" state is unreachable from anywhere inside a
+# git repository, because git's upward .git discovery finds this one. A project
+# has to sit outside every repository for MkX to report it has none.
+#
+# Nothing here touches your working tree. The workspace is left behind
+# deliberately — the point is to run mkx in it — and is yours to delete.
+#
+# Run via: make demo-git
+
+set -euo pipefail
+
+WORK="$(mktemp -d -t mkx-git-demo-XXXXXX)"
+
+# Local to this script, so the demo repositories do not depend on the machine's
+# git identity and do not inherit a global hooks or template directory.
+git_init() {
+	git init -q "$1"
+	git -C "$1" config user.email "demo@example.invalid"
+	git -C "$1" config user.name "mkx demo"
+	git -C "$1" config commit.gpgsign false
+}
+
+makefile() {
+	cat >"$1/Makefile" <<-'EOF'
+		.PHONY: hello slow
+
+		hello: ## Print a greeting
+			@echo "hello from $$(basename $$(pwd))"
+
+		slow: ## Sleep briefly, to watch the header re-read on return
+			@sleep 2 && echo done
+	EOF
+}
+
+# clean — a repository with a commit and nothing outstanding.
+mkdir -p "$WORK/clean"
+makefile "$WORK/clean"
+git_init "$WORK/clean"
+git -C "$WORK/clean" add -A
+git -C "$WORK/clean" commit -qm "initial"
+
+# dirty — the same, plus an untracked file. Untracked rather than modified on
+# purpose: `git status --porcelain` reports it, and a reader that only looked at
+# tracked changes would call this clean.
+mkdir -p "$WORK/dirty"
+makefile "$WORK/dirty"
+git_init "$WORK/dirty"
+git -C "$WORK/dirty" add -A
+git -C "$WORK/dirty" commit -qm "initial"
+echo "scratch" >"$WORK/dirty/untracked.txt"
+
+# detached — HEAD on a commit rather than a branch. `git rev-parse
+# --abbrev-ref HEAD` prints the literal "HEAD" here, exit 0.
+mkdir -p "$WORK/detached"
+makefile "$WORK/detached"
+git_init "$WORK/detached"
+git -C "$WORK/detached" add -A
+git -C "$WORK/detached" commit -qm "initial"
+git -C "$WORK/detached" checkout -q --detach
+
+# unborn — initialised, never committed. Prints the same literal "HEAD" as
+# detached above, and differs only in the exit code (128). This is the pair the
+# classifier has to tell apart.
+mkdir -p "$WORK/unborn"
+makefile "$WORK/unborn"
+git_init "$WORK/unborn"
+
+# norepo — a Makefile and no repository. An absence, not an error.
+mkdir -p "$WORK/norepo"
+makefile "$WORK/norepo"
+
+# broken — .git is a file holding text that is not a gitfile. git reports
+# "fatal: invalid gitfile format", which matches neither the not-a-repository
+# rule nor the unborn rule, so the read degrades to unknown. This is how a
+# failed read is forced with no test hooks in production code.
+#
+# The content matters: a .git file starting with "gitdir: " and a bad path
+# yields "fatal: not a git repository" instead, which classifies as ABSENT.
+# Verified against git 2.47.3.
+mkdir -p "$WORK/broken"
+makefile "$WORK/broken"
+printf 'this is not a gitfile\n' >"$WORK/broken/.git"
+
+cat <<EOF
+
+Demo workspace: $WORK
+
+Enter each project (↑↓ then Enter) and check the header segment:
+
+  clean       main ✓ clean        (green)
+  detached    detached ✓ clean    (yellow)
+  dirty       main ● dirty        (yellow)
+  norepo      no repo             (dimmed)
+  unborn      no commits          (dimmed)
+  broken      git unknown         (red)
+
+Then confirm, in that order:
+
+  1. The project list shows NO git column and no pause on startup.
+  2. "no repo", "git unknown" and "main ✓ clean" are three visibly
+     different things — not three greys.
+  3. In 'dirty', run the 'slow' target and confirm the header re-reads on
+     return rather than showing the state it had before.
+  4. In 'dirty', press R for the README and confirm the header re-reads too.
+  5. In 'dirty', press g (git pull; it will fail, there is no remote) and
+     confirm the header re-reads on return.
+
+Run it with:
+
+  cd $WORK && $(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/mkx
+
+Delete it with:
+
+  rm -rf $WORK
+
+EOF

--- a/scripts/demo-git.sh
+++ b/scripts/demo-git.sh
@@ -26,21 +26,41 @@ git_init() {
 	git -C "$1" config commit.gpgsign false
 }
 
+# The targets exist to make invalidation OBSERVABLE. A target that merely takes
+# a while proves nothing: the header re-reads to the same value, and the only
+# visible difference is a sub-millisecond "…" no human can catch. These three
+# change git state, so the header must come back showing something different —
+# which is a check that can actually fail.
+# printf rather than a heredoc, and not by preference: `<<-` strips leading
+# TABS, which is exactly the character make requires at the start of a recipe
+# line. A tab-indented heredoc here produces "missing separator" on every
+# target — silently, because nothing runs these until a human does.
 makefile() {
-	cat >"$1/Makefile" <<-'EOF'
-		.PHONY: hello slow
+	{
+		printf '.PHONY: hello dirty-it clean-it switch-branch\n\n'
+		printf 'hello: ## Print a greeting\n\t@echo "hello from $$(basename $$(pwd))"\n\n'
+		printf 'dirty-it: ## Leave an untracked file - header must flip to dirty\n\t@touch scratch.txt && echo "created scratch.txt"\n\n'
+		printf 'clean-it: ## Remove it again - header must flip back to clean\n\t@rm -f scratch.txt && echo "removed scratch.txt"\n\n'
+		printf 'switch-branch: ## Move to another branch - header must show the new name\n\t@git checkout -q -B demo-branch && echo "now on demo-branch"\n'
+	} >"$1/Makefile"
+}
 
-		hello: ## Print a greeting
-			@echo "hello from $$(basename $$(pwd))"
+# A README in every project, so `R` is a real tea.Exec handover. Without one,
+# ReadmePath returns "" and viewReadme short-circuits to a not-found message —
+# no handover at all, so pressing R would verify nothing about invalidation.
+# The first non-heading line also becomes the project's Description in the list.
+readme() {
+	cat >"$1/README.md" <<-EOF
+		# $(basename "$1")
 
-		slow: ## Sleep briefly, to watch the header re-read on return
-			@sleep 2 && echo done
+		Demo project for the mkx git-state verification pass.
 	EOF
 }
 
 # clean — a repository with a commit and nothing outstanding.
 mkdir -p "$WORK/clean"
 makefile "$WORK/clean"
+readme "$WORK/clean"
 git_init "$WORK/clean"
 git -C "$WORK/clean" add -A
 git -C "$WORK/clean" commit -qm "initial"
@@ -50,6 +70,7 @@ git -C "$WORK/clean" commit -qm "initial"
 # tracked changes would call this clean.
 mkdir -p "$WORK/dirty"
 makefile "$WORK/dirty"
+readme "$WORK/dirty"
 git_init "$WORK/dirty"
 git -C "$WORK/dirty" add -A
 git -C "$WORK/dirty" commit -qm "initial"
@@ -59,6 +80,7 @@ echo "scratch" >"$WORK/dirty/untracked.txt"
 # --abbrev-ref HEAD` prints the literal "HEAD" here, exit 0.
 mkdir -p "$WORK/detached"
 makefile "$WORK/detached"
+readme "$WORK/detached"
 git_init "$WORK/detached"
 git -C "$WORK/detached" add -A
 git -C "$WORK/detached" commit -qm "initial"
@@ -69,11 +91,13 @@ git -C "$WORK/detached" checkout -q --detach
 # classifier has to tell apart.
 mkdir -p "$WORK/unborn"
 makefile "$WORK/unborn"
+readme "$WORK/unborn"
 git_init "$WORK/unborn"
 
 # norepo — a Makefile and no repository. An absence, not an error.
 mkdir -p "$WORK/norepo"
 makefile "$WORK/norepo"
+readme "$WORK/norepo"
 
 # broken — .git is a file holding text that is not a gitfile. git reports
 # "fatal: invalid gitfile format", which matches neither the not-a-repository
@@ -85,6 +109,7 @@ makefile "$WORK/norepo"
 # Verified against git 2.47.3.
 mkdir -p "$WORK/broken"
 makefile "$WORK/broken"
+readme "$WORK/broken"
 printf 'this is not a gitfile\n' >"$WORK/broken/.git"
 
 cat <<EOF
@@ -102,14 +127,36 @@ Enter each project (↑↓ then Enter) and check the header segment:
 
 Then confirm, in that order:
 
-  1. The project list shows NO git column and no pause on startup.
+  1. The project list shows NO git column, no git state of any kind, and
+     no pause on startup.
   2. "no repo", "git unknown" and "main ✓ clean" are three visibly
      different things — not three greys.
-  3. In 'dirty', run the 'slow' target and confirm the header re-reads on
-     return rather than showing the state it had before.
-  4. In 'dirty', press R for the README and confirm the header re-reads too.
-  5. In 'dirty', press g (git pull; it will fail, there is no remote) and
-     confirm the header re-reads on return.
+
+  3. INVALIDATION, the one that can actually fail. Enter 'clean':
+
+       header reads          main ✓ clean
+       run 'dirty-it'   →    main ● dirty        (state changed under it)
+       run 'clean-it'   →    main ✓ clean        (and back)
+       run 'switch-branch' → demo-branch ✓ clean (branch re-read too)
+
+     If any of those still shows the previous value, RepoState was not
+     invalidated on return from the handover. This is the shared handover()
+     path, so it covers 'g' (git pull) as well as running a target.
+
+  4. README handover. In 'clean', press R, then Esc back.
+
+     Its invalidation cannot be made visually distinct — viewing a README
+     cannot change git state, so the re-read returns the same value by
+     construction. That the invalidation happens at all is covered by
+     TestHandoverWithNoInnerMessageStillInvalidates. What you are checking
+     here is the return path: the README renders, and you come back to a
+     correct, NON-BLANK header, not a stale or empty one. readme.go
+     returned a bare nil before this change and now returns a wrapper, so
+     the return path is what changed.
+
+  5. Caching. Enter 'clean', Esc, enter it again — the header shows its
+     value immediately with no "…" flicker, because the entry is cached.
+     After step 3's re-read, the brief "…" is visible again.
 
 Run it with:
 


### PR DESCRIPTION
Closes TAE-58. The architect plan this was built against is the approved plan comment on [TAE-58](https://linear.app/taelron/issue/TAE-58/git-state-gitreader-port-gitx-adapter-and-branch-display) — this PR implements it rather than re-deriving it.

Adds the **read** half of MkX's git support. Nothing here mutates: `git pull` and, later, `git checkout` stay on the handover path per ADR-M003.

---

## Two things the plan settles that a reader will ask about

**1. The project list shows no git state at all — reads are lazy on drill-in.**

A git read is issued when `Enter` opens a project's target view, and at no other time. The project list gets no git column and issues no reads; startup is untouched.

That is a deliberate consequence, not an oversight: **you cannot scan the project list for branch or dirty state.** To see a project's git state you drill into it. The trade is startup cost. Thirty projects on a cold cache means zero git subprocesses and no added startup latency; reading eagerly would mean ninety subprocesses before the TUI opens, with no TUI on screen while they run, and one hung repository delaying startup by the whole timeout. The acceptance criterion asks for the state of the **selected** Project, and in MkX `selectedProject` is set by `Enter` and nowhere else — drill-in is the exact moment that becomes meaningful.

Rejected alternatives, with reasons, are in §1 of the plan comment.

**2. The 2-second read timeout is a hardcoded constant, and the value is load-bearing.**

ADR-M004 bars a configuration surface, so `gitReadTimeout` is an unexported `const` in `internal/app` and there is no way for a user to raise it. That makes "why 2 and not 5" a fair question, and the answer is a calibration rather than a round number.

**What it is calibrated against.** A warm read of the three commands against a local repository is single-digit milliseconds. The worst case it is meant to survive is a **cold page cache over a large working tree on slow or networked storage**, where `git status --porcelain` has to stat every path: that pushes into the hundreds of milliseconds and can cross a second. Two seconds sits roughly two orders of magnitude above the warm case and comfortably above that worst case, while still being short enough that a genuinely stuck read resolves to `git unknown` while the user is still looking at the view rather than after they have moved on.

**What it deliberately does not budget for.** The obvious other stall — blocking on another process's `index.lock` while a concurrent `git` command holds it — is not covered by the timeout at all, because `--no-optional-locks` stops `git status` opportunistically refreshing and taking that lock in the first place. That converts "may block for as long as the other process runs" into "never attempts the lock", which is a stronger guarantee than any timeout value could give. Budgeting time for a lock wait instead would have meant a much larger number for a much weaker property.

The deadline covers the **whole** read, not each command: one `context.WithTimeout` in `App.RepoState` wraps all three, so a read that spends its budget on `status` fails the next command immediately rather than spawning it. And nothing blocks either way — the read is a `tea.Cmd`, so the target view is open and interactive throughout; the header shows `…` and then flips to `git unknown` in red.

---

## What was built, against the acceptance criteria

| Acceptance criterion | Where |
|---|---|
| `GitReader` port in `internal/app/ports.go`; adapter in `internal/adapter/gitx` | `ports.go`, `gitx/{gitx,parse}.go` |
| `RepoState` in `internal/domain` per the Domain Model | `domain/domain.go` |
| Resolved against the repository **containing** the Project | `gitx.go` — git's own upward `.git` discovery does this, so there is no root-walking code and no fourth `--show-toplevel` subprocess |
| Optional per Project; not-a-repository is not an error | `app.ErrNotARepository`, rendered as `no repo` |
| Captured reads, never handover; detached represented distinctly | three `git` reads into buffers (`rev-parse --abbrev-ref HEAD`, `status --porcelain`, `branch --format=%(refname:short)`); `domain.Head` discriminator |
| Bounded by a context timeout; degrades to unknown, never hangs | `gitReadTimeout` in `app`, applied in `App.RepoState` |
| Branch and dirty shown for the selected Project; unknown/absent/clean distinguishable | target-view header, seven states, four colours |
| Colours per @UI Patterns | `styles/styles.go` — `GitClean`/`GitAttention`/`GitUnknown`/`GitPending` |
| Invalidated on return from **every** `tea.Exec` handover | `handoverDone` + AST guard |
| Adapter logic tested against captured output as a pure function, not by invoking git | `gitx/parse_test.go` — no test in the repo spawns git |

### `RepoState` has four fields, and that is the documented entity

The Domain Model was amended to carry `Head` as a discriminator (on a branch / detached / unborn), with `Branch` empty unless `Head` is "on a branch". Unborn HEAD is named there as a normal state, not an error. Both of the plan's §11 flags are confirmed as it read them; the four-field shape is what this implements.

`Head` exists for a concrete reason:

```
git rev-parse --abbrev-ref HEAD
  detached  → exit 0    stdout "HEAD"
  unborn    → exit 128  stdout "HEAD"   stderr: fatal: ambiguous argument 'HEAD': …
```

Both print the literal `HEAD` on stdout. Only the exit code separates them, so `classifyHead` checks the exit code **before** it looks at stdout — a classifier reading stdout first reports an empty repository as detached. This is pinned as a regression test (`TestClassifyHead`, the "unborn HEAD is unborn, not detached, despite the same stdout" case). Verified against git 2.47.3, not assumed.

### Invalidation is structural, not remembered

`handover()` now wraps every message in `handoverDone`. `Update` unwraps it before its own switch, clears the whole cache, bumps a generation counter, and re-issues a read when a target view is open — so the existing message cases are untouched and a handover added later invalidates with nothing to remember at the call site.

`readme.go` is routed through it rather than exempted. Viewing a README cannot change a branch, so an exemption is arguable — but it returned a bare `nil` from its `tea.Exec` before this change, which is precisely why a rule phrased as "invalidate in each handover's case" could never have covered it. Routing it through costs one redundant sub-second re-read and buys ADR-M003's rule with zero exceptions.

`internal/ui/tui/handover_guard_test.go` parses every non-test file in the package and fails if any `tea.Exec` callback does not construct `handoverDone`. There is no file allowlist — which files hold a handover today is exactly the fact a new file makes stale.

**The guard is shown to reject, not merely to pass.** A green run of a verification mechanism is the weakest possible evidence it works. So the checker is a pure function over parsed source, driven from a table of synthetic bypasses — including `readme.go`'s exact pre-TAE-58 shape — and asserted to reject each. It also carries a non-vacuity assertion, so a glob that matched nothing cannot pass by finding nothing. Separately, during this work `readme.go` was reverted to `return nil` in the real tree and the guard was confirmed to go red at `readme.go:79` before being restored.

### Absence cannot read as clean

The AC's central hazard is guarded on three independent levels:

1. `gitSegment` has **no** code path returning `""`, including the never-asked case.
2. `clean` is spelled out, not signalled by the lack of a dirty marker.
3. `domain.RepoState`'s zero value is `HeadUnknown`, so a state that reached the renderer unfilled reads as unknown — the same discipline `PhonyStatus` already applies.

A fourth guard sits in the adapter: a failed `git status` is checked rather than ignored, because an unchecked failure returns empty output and `parseDirty("")` would fabricate `Dirty: false` — the same bug relocated one call deeper.

### Display

```
mkx › MKX  main ✓ clean                                          3/9    green
mkx › MKX  main ● dirty                                          3/9    yellow
mkx › MKX  detached ● dirty                                      3/9    yellow
mkx › MKX  no commits                                            3/9    dimmed
mkx › MKX  git unknown                                           3/9    red
mkx › MKX  no repo                                               3/9    dimmed
mkx › MKX  …                                                     3/9    dimmed
```

The must-distinguish trio gets three different **colours**, not merely three different words: unknown is red (a failed read is a failure), absent is dimmed (muted, explicitly not an error), clean is green. Blue is deliberately unused — it belongs to the adjacent header title.

---

## Verification handoff

Run top to bottom. `verify-gitx` and `demo-git` are new; the rest already existed.

| # | Command | Purpose | Expected |
|---|---|---|---|
| 1 | `make build` | Compiles against the new `app.New` signature and wiring | Builds, no error |
| 2 | `make verify-gitx` | Pure classifier and parser table tests | Green. **No git process is spawned** — these never call `Reader.State` |
| 3 | `make verify` | Golden characterization | Green, **no diff, no rebaseline** (see below) |
| 4 | `make verify-parser` | Make adapter, untouched | Green |
| 5 | `make verify-tui` | TUI suite: seven display states, cache seed/hit, stale-gen discard, invalidation, the AST guard and its synthetic bypass table | Green. Needed no Makefile change — it already globs the package |
| 6 | `make verify-guards` | Pre-existing oracle guards still fire | Green — "All guards tripped as required." |
| 7 | `make test` | Full suite | Green |
| 8 | `make tidy-check` | `gitx` is stdlib-only | No diff |
| 9 | `make demo-git` | Builds a throwaway workspace covering all six git states | Prints the workspace path and a checklist |
| 10 | `cd <that path> && <repo>/mkx` | The visual pass | See below |

All eight of steps 1–8 were run and pass, and were re-run from a fresh `git clone --no-local` of this branch **after the `--format` change** — so nothing green depends on an uncommitted file. The clean clone was left with an empty `git status` afterwards, so no target rewrote anything in the tree.

**On step 3.** `make verify` must not move the golden, and cannot: `serializeProjects` reads only project name, description and target fields; `domain.Project` is unchanged; `DiscoverProjects` never calls the git reader; and `RepoState` lives in the TUI's cache, never in discovery output. The only change to `characterization_test.go` is a third argument to `app.New` so the file compiles. **If it reports a diff, something touched discovery and this PR is out of scope — do not rebaseline.**

**Step 10, by hand.** `demo-git` builds its workspace under a temp directory rather than inside this repo for a specific reason: the `no repo` state is unreachable from anywhere inside a git repository, because git's upward discovery finds *this* one.

| Project | Expected header |
|---|---|
| `clean` | `main ✓ clean` (green) |
| `dirty` | `main ● dirty` (yellow) |
| `detached` | `detached ✓ clean` (yellow) |
| `unborn` | `no commits` (dimmed) |
| `norepo` | `no repo` (dimmed) |
| `broken` | `git unknown` (red) |

**The invalidation check is the one that can actually fail.** The demo Makefile carries three targets that *change git state*, so the header must come back showing something different — rather than a target that merely takes a while, where the re-read returns the same value and the only visible difference is a sub-millisecond `…` no human can catch. In `clean`:

```
header reads            main ✓ clean
run 'dirty-it'      →   main ● dirty          (state changed underneath it)
run 'clean-it'      →   main ✓ clean          (and back)
run 'switch-branch' →   demo-branch ✓ clean   (branch re-read too)
```

If any of those still shows the previous value, `RepoState` was not invalidated on return. This is the shared `handover()` path, so it covers `g` (git pull) as well as running a target.

**The README step is honest about its own limit.** Viewing a README cannot change git state, so its invalidation returns the same value by construction and is *not* visually distinguishable — that is covered by `TestHandoverWithNoInnerMessageStillInvalidates`. What the manual step checks is the **return path**: the README renders and you come back to a correct, non-blank header. `readme.go` returned a bare `nil` before this change and now returns a wrapper, so the return path is the thing that actually changed.

Then also confirm: the project list shows **no git column and no startup pause**; `no repo`, `git unknown` and `main ✓ clean` are three visibly different things; and re-entering a project shows its value immediately with no `…` flicker, because the entry is cached.

`broken` is how a failed read is forced with no test hooks in production code. Its `.git` holds **pure garbage**, which yields `fatal: invalid gitfile format` — matching neither classifier rule, so it lands in unknown. This is a correction to the plan: a `.git` file starting with `gitdir: ` and a bad path instead yields `fatal: not a git repository`, which classifies as **absent**, the wrong state. Both phrasings were checked against git 2.47.3.

### Evidence the adapter itself works

The committed tests never invoke git, by design. So the real adapter was separately probed against the `demo-git` workspace with a throwaway test file (not committed):

```
clean      head=on branch  branch="main"  dirty=false  branches=[main]
dirty      head=on branch  branch="main"  dirty=true   branches=[main]
detached   head=detached   branch=""      dirty=false  branches=[main]
unborn     head=unborn     branch=""      dirty=true   branches=[]
norepo     ABSENT
broken     UNKNOWN (git rev-parse: exit 128: fatal: invalid gitfile format: …)
multi      head=detached   branch=""      dirty=false  branches=[develop feature/foo main]
```

The `multi` row is the one that exercises the pseudo-entry filter on the real path: a repository with three branches and a detached HEAD, where `git branch --format=%(refname:short)` emits `(HEAD detached at …)` first and the three real branches after it. Only the three reach `RepoState.Branches`.

---

## Notes for review

**The branch read uses `--format`, and this corrects the issue text.** ADR-M003's Decision section names `git branch --format=...`; TAE-58's acceptance criteria originally said plain `git branch`, which was an error in the issue that propagated into the plan. The AC has since been amended to name the flag, so the issue and the ADR agree, and the second commit on this branch brings the code into line rather than deferring it to TAE-59.

One thing about that change is worth stating, because it is not what it looked like from the outside. **`--format` removes the marker column but not the pseudo-entry.** The two-character column (`* `, `+ `, `  `) genuinely disappears, so the strip and the worktree-marker test that only covered it are deleted. But git still synthesises a non-branch entry when HEAD is not on a branch, and it appears in `--format` output alongside the real branches. Both of these are captured from git 2.47.3:

```
(HEAD detached at c5020c5)
(no branch, bisect started on main)
```

So the shape-based filter stays, and its table now carries the second phrasing as well as the first — which is what shows the rule holds without the parser having to enumerate git's wordings. A case was added for the opposite direction too: a parenthesised name with **no** space is a legal refname and is kept, so the rule cannot discard a real branch. Removing the filter was checked to turn both retained cases red, so they are not passing vacuously.

`Branches` still has no consumer until TAE-59, and discovery reads no git state, so nothing downstream changed and the golden did not move — `testdata/` is byte-identical to `main`.

**What TAE-59 inherits.** Its branch picker is openable from the project view, where by design nothing is cached — so it must issue its own read on open and show a loading state in the modal. The cache and read machinery here are Model-level and keyed by project name precisely so that is a reuse rather than a new mechanism. Its `git checkout` is a `domain.Command` through the existing `handover()`, so it gets invalidation with no new plumbing, and the AST guard catches it if anyone reaches for `tea.Exec` directly.

**One pre-existing test needed a fixture change, not a weakened assertion.** `TestHelpFitsAtEightyByTwentyFour` uses `…` as its truncation sentinel, and the in-flight git marker is the same glyph. The `helpView` fixture now seeds a resolved git state, so the guard checks exactly what it was written to check; the assertion itself is untouched.

**The demo script's first version was broken, and running it is what found that.** Three defects, all in the verification surface rather than production code, fixed in the third commit:

- Every demo Makefile was **unrunnable**. The recipes lived in a `<<-'EOF'` heredoc, and `<<-` strips leading **tabs** — exactly the character make requires to start a recipe line. Every target died with `missing separator`. Nothing caught it because nothing runs those targets until a human does; the script's own output looked perfect. It now builds the Makefile with `printf`, where the tab is an explicit `\t` no quoting form can eat.
- The **README step could not test what it claimed**. No project had a README, so `ReadmePath` returned `""` and `viewReadme` short-circuited to a not-found message — not a `tea.Exec`, so no handover and no invalidation at all. Every project now carries a `README.md`.
- The **invalidation step was unobservable**, as described above.

This is worth stating plainly: a verification handoff that has never been executed is a claim, not evidence. Two of the five manual steps would have verified nothing, and one of them could not have run.

**Three `code-reviewer` passes** (correctness, simplicity/DRY, conventions & ADR adherence) were run in-session and returned no findings at their confidence bar. They reviewed the first commit; the `--format` change and the demo-script fix landed after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
