### PR TITLE
Branch switching: picker modal and checkout handover

### DIFF
--- a/internal/app/usecases.go
+++ b/internal/app/usecases.go
@@ -5,6 +5,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -80,6 +81,36 @@ func (a *App) RunTarget(ctx context.Context, project domain.Project, targetName 
 // discovered before it is stale.
 func (a *App) PullAndRefresh(ctx context.Context, project domain.Project) (domain.Command, error) {
 	return domain.Command{Argv: []string{"git", "pull"}, WorkDir: project.Path}, nil
+}
+
+// CheckoutBranch returns the command that switches the project's repository to
+// the named branch.
+//
+// state is the RepoState the caller is acting on — the same value the UI drew
+// its options from, not a fresh read. Validating against the caller's snapshot
+// is what keeps the answer consistent with what the user was looking at; a
+// branch that has since disappeared from the repository is git's refusal to
+// report, not this function's to pre-empt.
+//
+// What it refuses is its own argument: an empty name, a repository with no
+// commits, and a branch the given state does not list. That is the same shape
+// as RunTarget refusing a target the Project does not declare.
+//
+// What it deliberately does not do is pre-validate the checkout. Per ADR-M003
+// MkX does not refuse on a dirty tree, does not stash, and does not offer
+// --force: a dirty state still yields a command, and git reports its own
+// outcome in its own words. The distinction is argument validation versus
+// checkout policy, and only the first belongs here.
+func (a *App) CheckoutBranch(ctx context.Context, project domain.Project, state domain.RepoState, branch string) (domain.Command, error) {
+	switch {
+	case branch == "":
+		return domain.Command{}, fmt.Errorf("project %q: no branch to check out", project.Name)
+	case state.Head == domain.HeadUnborn:
+		return domain.Command{}, fmt.Errorf("project %q has no commits yet, so it has no branches", project.Name)
+	case !slices.Contains(state.Branches, branch):
+		return domain.Command{}, fmt.Errorf("project %q has no local branch %q", project.Name, branch)
+	}
+	return domain.Command{Argv: []string{"git", "checkout", branch}, WorkDir: project.Path}, nil
 }
 
 // RefreshTargets re-discovers a project's targets after a handover.

--- a/internal/app/usecases_test.go
+++ b/internal/app/usecases_test.go
@@ -227,6 +227,108 @@ func TestPullAndRefresh(t *testing.T) {
 	}
 }
 
+// TestCheckoutBranch checks the checkout descriptor and the three arguments
+// the use case refuses.
+func TestCheckoutBranch(t *testing.T) {
+	project := domain.Project{Name: "alpha", Path: "/w/alpha"}
+	onMain := domain.RepoState{
+		Head:     domain.HeadOnBranch,
+		Branch:   "main",
+		Branches: []string{"main", "feature"},
+	}
+	application := newApp(&fakeScanner{}, &fakeRunner{})
+
+	got, err := application.CheckoutBranch(context.Background(), project, onMain, "feature")
+	if err != nil {
+		t.Fatalf("CheckoutBranch: %v", err)
+	}
+	assertCommand(t, got, []string{"git", "checkout", "feature"}, "/w/alpha")
+
+	// The branch already checked out is not special-cased: git says "Already
+	// on 'main'" and that is a better answer than one MkX invents.
+	if _, err := application.CheckoutBranch(context.Background(), project, onMain, "main"); err != nil {
+		t.Errorf("CheckoutBranch onto the current branch: %v, want a command", err)
+	}
+
+	refusals := []struct {
+		name   string
+		state  domain.RepoState
+		branch string
+	}{
+		{
+			name:   "a branch the state does not list",
+			state:  onMain,
+			branch: "nope",
+		},
+		{
+			name:   "a repository with no commits",
+			state:  domain.RepoState{Head: domain.HeadUnborn},
+			branch: "main",
+		},
+		{
+			name:   "an empty branch name",
+			state:  onMain,
+			branch: "",
+		},
+	}
+
+	for _, tt := range refusals {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, err := application.CheckoutBranch(context.Background(), project, tt.state, tt.branch)
+			if err == nil {
+				t.Fatalf("got the command %+v, want a refusal", cmd)
+			}
+			if len(cmd.Argv) != 0 {
+				t.Errorf("a refusal still carried a command: %+v", cmd)
+			}
+		})
+	}
+}
+
+// TestCheckoutBranchDoesNotPreValidateTheCheckout is the distinction ADR-M003
+// draws, pinned so it cannot erode into "helpfully" refusing.
+//
+// Argument validation — is this a branch this state knows about — belongs in
+// the use case. Checkout policy does not: MkX must not refuse on a dirty tree,
+// must not stash, and must not offer --force. A dirty state that still yields a
+// command is what proves the first without the second, and git remains the sole
+// judge of whether the checkout can proceed.
+func TestCheckoutBranchDoesNotPreValidateTheCheckout(t *testing.T) {
+	project := domain.Project{Name: "alpha", Path: "/w/alpha"}
+	dirty := domain.RepoState{
+		Head:     domain.HeadOnBranch,
+		Branch:   "main",
+		Dirty:    true,
+		Branches: []string{"main", "feature"},
+	}
+
+	got, err := newApp(&fakeScanner{}, &fakeRunner{}).
+		CheckoutBranch(context.Background(), project, dirty, "feature")
+	if err != nil {
+		t.Fatalf("a dirty tree was refused: %v — ADR-M003 leaves that judgement to git", err)
+	}
+	assertCommand(t, got, []string{"git", "checkout", "feature"}, "/w/alpha")
+
+	for _, arg := range got.Argv {
+		if arg == "--force" || arg == "-f" || arg == "stash" {
+			t.Errorf("the command carries %q: %+v", arg, got.Argv)
+		}
+	}
+}
+
+// A detached HEAD has no current branch, and switching to one is a legitimate
+// escape rather than a state to refuse.
+func TestCheckoutBranchFromADetachedHead(t *testing.T) {
+	detached := domain.RepoState{Head: domain.HeadDetached, Branches: []string{"main"}}
+
+	got, err := newApp(&fakeScanner{}, &fakeRunner{}).CheckoutBranch(
+		context.Background(), domain.Project{Name: "alpha", Path: "/w/alpha"}, detached, "main")
+	if err != nil {
+		t.Fatalf("CheckoutBranch from a detached head: %v", err)
+	}
+	assertCommand(t, got, []string{"git", "checkout", "main"}, "/w/alpha")
+}
+
 // TestReadmePath checks the use case passes the project's directory — not its
 // name — through to the scanner, and reports "" for a project with no README.
 func TestReadmePath(t *testing.T) {

--- a/internal/ui/tui/exec.go
+++ b/internal/ui/tui/exec.go
@@ -102,6 +102,20 @@ func targetStatus(exitCode int, _ error, d time.Duration) string {
 	return fmt.Sprintf("%s (%s)", status, d.Round(time.Second))
 }
 
+// checkoutStatus reports whether the checkout succeeded, quoting git's own
+// error.
+//
+// It names no branch, on either path. Git has already printed "Switched to
+// branch 'x'" — or its refusal — one line above this, and git's line is the
+// only one on screen written by something that read where HEAD actually
+// points.
+func checkoutStatus(_ int, err error, _ time.Duration) string {
+	if err != nil {
+		return fmt.Sprintf("✗ %v", err)
+	}
+	return "✓ checkout complete"
+}
+
 // pullStatus reports whether git pull succeeded, quoting git's own error.
 func pullStatus(_ int, err error, _ time.Duration) string {
 	if err != nil {

--- a/internal/ui/tui/keymap_views.go
+++ b/internal/ui/tui/keymap_views.go
@@ -131,6 +131,12 @@ func targetKeymap() keymap {
 				}
 				return m, m.runTarget(proj, targets[m.targetCursor])
 			}},
+		// Target view only. TAE-58 reads git state lazily on drill-in, so no
+		// RepoState exists while the project list is showing and the picker
+		// would have nothing to populate from.
+		{keys: []string{"b"}, display: "b", label: "Branch",
+			help: "Switch the checked-out branch", inBar: true,
+			handler: openBranchModal},
 		{keys: []string{"g"}, display: "g", label: "Pull",
 			help: "Git pull and re-read targets", inBar: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {

--- a/internal/ui/tui/modal.go
+++ b/internal/ui/tui/modal.go
@@ -6,6 +6,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
 	"github.com/Gaetan-Jaminon/mkx/internal/ui/tui/styles"
 )
 
@@ -17,8 +18,15 @@ type modalContent int
 const (
 	modalNone modalContent = iota
 	modalHelp
-	// The M2 branch picker lands here, and costs one enum value, one
-	// renderModalBody case, one keymap func and one showModal call.
+	// modalBranchPicker is the select picker over a repository's local
+	// branches. It is the one content type whose body windows rather than
+	// fits — see renderBranchPickerBody for the @UI Patterns rule that
+	// permits it.
+	modalBranchPicker
+	// modalNotice is a read-only sentence: the legible reason a branch
+	// picker cannot be shown. Info content, so its bar closes rather than
+	// confirms.
+	modalNotice
 )
 
 // modalInput is the cursor and text state interactive content types need. Info
@@ -42,6 +50,23 @@ type modalState struct {
 	// type shows the prescribed Enter/Confirm  Esc/Cancel.
 	keys  keymap
 	input modalInput
+
+	// repo is the git state the modal was opened against, snapshotted once
+	// when it opened.
+	//
+	// It is the modal's single source: the picker's rows are repo.Branches,
+	// the (current) marker is repo.Branch, and app.CheckoutBranch validates
+	// the selection against this same value. m.gitCache is deliberately not
+	// consulted again while the modal is up — a read landing mid-modal
+	// replaces that entry, and validating a visible row against a list the
+	// user cannot see is a refusal for a branch on screen in front of them.
+	//
+	// The guarantee is internal consistency, not currency: a branch deleted
+	// on disk while the modal is open is git's refusal to report, per
+	// ADR-M003, not MkX's to pre-empt.
+	repo domain.RepoState
+	// notice is modalNotice's sentence.
+	notice string
 }
 
 // showModal opens a modal over the current view.
@@ -162,6 +187,11 @@ func (m Model) renderModalBody() string {
 		// The underlying view's keymap, not the modal's own — that is what
 		// makes help context-sensitive.
 		return renderHelpBody(m.viewKeymap())
+	case modalBranchPicker:
+		return renderBranchPickerBody(
+			m.modal.repo.Branches, m.modal.repo.Branch, m.modal.input.cursor, branchPickerRows)
+	case modalNotice:
+		return renderNoticeBody(m.modal.notice, m.modalMaxInnerWidth())
 	}
 	return ""
 }

--- a/internal/ui/tui/modal_branch.go
+++ b/internal/ui/tui/modal_branch.go
@@ -1,0 +1,255 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+)
+
+// The branch picker: the `b` key's whole surface.
+//
+// The load-bearing property of this file is that nothing in it ever names a
+// branch it did not just read. The picker's rows come from a RepoState
+// snapshot, the checkout carries that same snapshot into app.CheckoutBranch,
+// and the header segment afterwards comes from a fresh read issued by the
+// handover invalidation — never from the checkout's exit code, and never from
+// the branch the user selected. A refused checkout therefore cannot produce a
+// display claiming the new branch, because no code path exists that could
+// write one.
+
+// branchPickerRows is how many branch rows the picker shows at once.
+//
+// The box is fixed at this height whatever the repository holds: seven rows,
+// the "… N more" line, header, hint bar, two rules and two borders is 13 lines,
+// which leaves room at the 80×24 floor @UI Patterns requires modals to fit.
+const branchPickerRows = 7
+
+// renderBranchPickerBody renders the option list: one row per branch, the
+// cursor on one of them, "(current)" against the branch the snapshot says is
+// checked out, and a count of what the window hides.
+//
+// It windows rather than growing, which @UI Patterns permits for exactly this
+// content: "a select picker over an unbounded option list may window its
+// options within a fixed-height box. The box does not grow, the header and hint
+// bar are never pushed out, and the number of hidden options is stated
+// explicitly." The alternative is not a taller box — buildModalBox has no
+// height clamp and splice silently drops overflowing lines, so a thirty-branch
+// repository would lose its hint bar and bottom border with no signal at all.
+//
+// It is a pure function over display data — two strings and two ints, no Model,
+// no RepoState — so every windowing and marking rule below is table-testable.
+//
+// current is matched by string equality, not by prefix or containment: a
+// repository holding both `main` and `main-2` must mark exactly one of them,
+// and a detached HEAD (whose Branch is empty) must mark neither.
+func renderBranchPickerBody(options []string, current string, cursor, maxRows int) string {
+	if len(options) == 0 {
+		// Not reachable through openBranchModal, which routes an empty list
+		// to a notice. Kept because renderModalBody is reachable from any
+		// modalBranchPicker state, and a blank body is the silent empty state
+		// @UI Patterns forbids.
+		return "No local branches to switch to."
+	}
+
+	// Column width from the data, per @UI Patterns — from every option rather
+	// than the visible window, so the marker does not shift as the cursor
+	// pages.
+	nameCol := 0
+	for _, name := range options {
+		if w := ansi.StringWidth(name); w > nameCol {
+			nameCol = w
+		}
+	}
+
+	// The same offset arithmetic the two list views use: the window starts at
+	// the top and follows the cursor down, so it always contains the cursor.
+	offset := 0
+	if cursor >= maxRows {
+		offset = cursor - maxRows + 1
+	}
+	end := min(offset+maxRows, len(options))
+
+	rows := make([]string, 0, maxRows+1)
+	for i := offset; i < end; i++ {
+		row := "   "
+		if i == cursor {
+			row = " ▸ "
+		}
+		row += fmt.Sprintf("%-*s", nameCol, options[i])
+		if options[i] == current {
+			row += "  (current)"
+		}
+		// The name column's padding is trailing whitespace on every row but
+		// the current one, and buildModalBox counts it: an unTrimmed row of
+		// spaces past the inner width comes back ellipsised for no visible
+		// reason.
+		rows = append(rows, strings.TrimRight(row, " "))
+	}
+
+	if hidden := len(options) - (end - offset); hidden > 0 {
+		rows = append(rows, fmt.Sprintf("   … %d more", hidden))
+	}
+
+	return strings.Join(rows, "\n")
+}
+
+// renderNoticeBody renders a notice's sentence, wrapped to the modal's inner
+// width.
+//
+// Wrapped rather than clamped: buildModalBox truncates an over-wide line with
+// an ellipsis, which for a sentence explaining why the picker is unavailable
+// would hide the explanation. Notices are authored and short, so wrapping them
+// keeps the whole reason on screen and the modal still fits — the @UI Patterns
+// exception this file uses for the picker's option list explicitly does not
+// extend to info content.
+func renderNoticeBody(text string, inner int) string {
+	return ansi.WrapWc(text, inner, "-")
+}
+
+// branchPickerKeymap is the picker's own bindings, and its hint bar: the
+// baseline's prescribed Enter/Confirm  Esc/Cancel plus the navigation key it
+// permits a picker to add.
+func branchPickerKeymap() keymap {
+	return keymap{
+		{keys: []string{"up", "k"}, display: "↑↓", label: "Navigate",
+			help: "Move the cursor up", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				if m.modal.input.cursor > 0 {
+					m.modal.input.cursor--
+				}
+				return m, nil
+			}},
+		{keys: []string{"down", "j"}, display: "↑↓", label: "Navigate",
+			help: "Move the cursor down", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				if m.modal.input.cursor < len(m.modal.repo.Branches)-1 {
+					m.modal.input.cursor++
+				}
+				return m, nil
+			}},
+		{keys: []string{"enter"}, display: "Enter", label: "Confirm",
+			help: "Check out the selected branch", inBar: true,
+			handler: confirmBranch},
+		{keys: []string{"esc"}, display: "Esc", label: "Cancel",
+			help: "Close without switching", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				return m.closeModal(), nil
+			}},
+	}
+}
+
+// noticeKeymap is a notice's bindings. Esc/Close rather than Enter/Confirm,
+// following the help overlay: there is nothing to confirm, and a bar
+// advertising a no-op Enter is worse than one that omits it.
+func noticeKeymap() keymap {
+	return keymap{
+		{keys: []string{"esc"}, display: "Esc", label: "Close",
+			help: "Close this notice", inBar: true,
+			handler: func(m Model, _ string) (Model, tea.Cmd) {
+				return m.closeModal(), nil
+			}},
+	}
+}
+
+// openBranchModal is the `b` handler. The modal always opens; only its body
+// varies. Every state that has no branch list gets a sentence saying so —
+// @UI Patterns forbids a silent empty state, and a key that does nothing is
+// exactly that.
+//
+// The git cache is read here, once. Everything downstream — the rows, the
+// marker, the validation — reads the snapshot this puts on modalState.
+func openBranchModal(m Model, _ string) (Model, tea.Cmd) {
+	proj, ok := m.currentProject()
+	if !ok {
+		return m, nil
+	}
+
+	entry, cached := m.gitCache[proj.Name]
+
+	switch {
+	case !cached || entry.status == gitLoading:
+		return m.showNotice(proj, "Still reading this project's git state. Try again in a moment."), nil
+	case entry.status == gitAbsent:
+		return m.showNotice(proj, "This project is not in a git repository, so it has no branches to switch between."), nil
+	case entry.status == gitUnknown:
+		return m.showNotice(proj, "This project's git state could not be read, so its branches are unknown."), nil
+	case entry.state.Head == domain.HeadUnborn:
+		return m.showNotice(proj, "This repository has no commits yet, so there are no branches to switch to."), nil
+	case len(entry.state.Branches) == 0:
+		return m.showNotice(proj, "This repository reports no local branches to switch to."), nil
+	}
+
+	// Detached HEAD needs no case of its own: state.Branch is empty, so no row
+	// matches, nothing is marked current, and the cursor opens at the top.
+	// Checking out a branch is a legitimate escape from a detached head, so
+	// nothing is disabled.
+	cursor := 0
+	for i, name := range entry.state.Branches {
+		if name == entry.state.Branch {
+			cursor = i
+			break
+		}
+	}
+
+	m = m.showModal(modalBranchPicker, "Switch branch", proj.Name,
+		modalInput{cursor: cursor}, branchPickerKeymap())
+	m.modal.repo = entry.state
+	return m, nil
+}
+
+// showNotice opens the modal on a one-sentence explanation.
+func (m Model) showNotice(proj domain.Project, text string) Model {
+	m = m.showModal(modalNotice, "Switch branch", proj.Name, modalInput{}, noticeKeymap())
+	m.modal.notice = text
+	return m
+}
+
+// confirmBranch is Enter inside the picker: close the modal and hand the
+// terminal to git.
+//
+// The branch and the snapshot are both taken before closeModal, which clears
+// modalState — and the snapshot is taken from the modal rather than re-read
+// from the cache, which is the whole point of holding it.
+func confirmBranch(m Model, _ string) (Model, tea.Cmd) {
+	proj, ok := m.currentProject()
+	if !ok {
+		return m.closeModal(), nil
+	}
+	branches := m.modal.repo.Branches
+	if m.modal.input.cursor < 0 || m.modal.input.cursor >= len(branches) {
+		return m.closeModal(), nil
+	}
+
+	cmd := m.checkout(proj, branches[m.modal.input.cursor])
+	return m.closeModal(), cmd
+}
+
+// checkout asks the app for the checkout command and hands the terminal to it,
+// through the same handover() every other MkX subprocess goes through. That is
+// what keeps this package at two tea.Exec sites and makes ADR-M003's "RepoState
+// is invalidated by every handover" cover the checkout with nothing written for
+// it.
+//
+// The RepoState it validates against is m.modal.repo — the snapshot the rows
+// were drawn from. m.gitCache is not consulted here; see modalState.repo.
+//
+// Selecting the branch already checked out is allowed and hands over normally:
+// git says "Already on 'main'". Special-casing it would be pre-validation in
+// miniature, for no gain.
+func (m Model) checkout(proj domain.Project, branch string) tea.Cmd {
+	cmd, err := m.app.CheckoutBranch(m.rootCtx, proj, m.modal.repo, branch)
+	if err != nil {
+		return func() tea.Msg { return runFailedMsg{err: err} }
+	}
+
+	return handover(cmd, proj.Name, checkoutStatus, func(*commandExec) tea.Msg {
+		// Deliberately empty. Nothing about the outcome travels back into the
+		// TUI: what the header shows next comes from the re-read the wrapper
+		// triggers, and an exit code is not a reading of where HEAD points.
+		return checkoutFinishedMsg{}
+	})
+}

--- a/internal/ui/tui/modal_branch_test.go
+++ b/internal/ui/tui/modal_branch_test.go
@@ -1,0 +1,703 @@
+package tui
+
+// The branch picker's tests. Nothing here spawns git or checks anything out:
+// the App is wired with fakeGitReader, the picker is driven through its real
+// keymap, and the return from the handover is simulated by feeding Update the
+// same handoverDone wrapper tea.Exec would have produced.
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/app"
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+)
+
+// pickerModel is a Model on alpha's target list with the given git state
+// cached, ready for `b`.
+func pickerModel(state domain.RepoState) Model {
+	return testModel().setGitEntry("alpha", gitEntry{status: gitOK, state: state})
+}
+
+// openPicker presses `b` and asserts the picker — not a notice — opened.
+func openPicker(t *testing.T, m Model) Model {
+	t.Helper()
+
+	opened, cmd := targetKeymap().dispatch("b")(m, "b")
+	if cmd != nil {
+		t.Error("`b` issued a command; opening the picker reads nothing")
+	}
+	if !opened.modal.active {
+		t.Fatal("`b` opened no modal")
+	}
+	if opened.modal.content != modalBranchPicker {
+		t.Fatalf("`b` opened content %v, want the branch picker (body: %q)",
+			opened.modal.content, opened.renderModalBody())
+	}
+	return opened
+}
+
+// press sends a key to the open modal's own keymap.
+func press(t *testing.T, m Model, key string) (Model, tea.Cmd) {
+	t.Helper()
+
+	h := m.modal.keys.dispatch(key)
+	if h == nil {
+		t.Fatalf("the modal does not bind %q", key)
+	}
+	return h(m, key)
+}
+
+// runCmd executes cmd and everything a tea.Batch fans it out into, returning
+// the messages produced. A tea.Exec command yields its internal message
+// without running any subprocess, so this is safe on the checkout path.
+func runCmd(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var out []tea.Msg
+		for _, c := range batch {
+			out = append(out, runCmd(c)...)
+		}
+		return out
+	}
+	return []tea.Msg{msg}
+}
+
+// returnFromHandover drives the return path a real tea.Exec would take: Update
+// unwraps the handover, invalidates, re-issues the git read, and this folds
+// that read's answer back in. What the model shows afterwards therefore comes
+// from the fakeGitReader — that is, from a read — and from nothing else.
+func returnFromHandover(t *testing.T, m Model, inner tea.Msg) Model {
+	t.Helper()
+
+	updated, cmd := m.Update(handoverDone{inner: inner})
+	after := updated.(Model)
+	if cmd == nil {
+		t.Fatal("the handover return issued no command; the re-read is missing")
+	}
+
+	reads := 0
+	for _, msg := range runCmd(cmd) {
+		if state, ok := msg.(gitStateMsg); ok {
+			after = after.applyGitState(state)
+			reads++
+		}
+	}
+	if reads != 1 {
+		t.Fatalf("the handover return produced %d git reads, want exactly 1", reads)
+	}
+	return after
+}
+
+func header(m Model) string {
+	return ansi.Strip(strings.SplitN(m.renderTargetList(), "\n", 2)[0])
+}
+
+// ------------------------------------------------------- the option list
+
+// TestBranchPickerMarksTheCurrentBranch covers the marker rule and the two
+// ways it can go wrong: marking more than one row, and marking a row whose
+// name merely resembles the current branch.
+func TestBranchPickerMarksTheCurrentBranch(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []string
+		current string
+		want    string // the row that must carry the marker, "" for none
+	}{
+		{
+			name:    "on a branch",
+			options: []string{"feat/api", "main", "release/2.1"},
+			current: "main",
+			want:    "main",
+		},
+		{
+			// A detached HEAD has an empty Branch, so nothing matches and
+			// nothing is marked. No special case needed for it anywhere.
+			name:    "detached",
+			options: []string{"feat/api", "main"},
+			current: "",
+		},
+		{
+			// String equality, not prefix: main, main-2 and mainline are three
+			// different branches and only one of them is checked out. The
+			// current branch is deliberately the *shortest* here — a prefix
+			// test marks all three, an equality test marks one.
+			name:    "the current branch is a prefix of two others",
+			options: []string{"main", "main-2", "mainline"},
+			current: "main",
+			want:    "main",
+		},
+		{
+			// And not containment either, in the other direction.
+			name:    "the current branch is contained in another",
+			options: []string{"feature/main", "main"},
+			current: "main",
+			want:    "main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := renderBranchPickerBody(tt.options, tt.current, 0, branchPickerRows)
+
+			marked := []string{}
+			for _, row := range strings.Split(body, "\n") {
+				if strings.Contains(row, "(current)") {
+					marked = append(marked, strings.TrimSpace(row))
+				}
+			}
+
+			if tt.want == "" {
+				if len(marked) != 0 {
+					t.Errorf("nothing is checked out, but %v is marked current", marked)
+				}
+				return
+			}
+			if len(marked) != 1 {
+				t.Fatalf("%d rows marked current, want exactly 1: %v\n%s", len(marked), marked, body)
+			}
+			if !strings.HasPrefix(marked[0], tt.want+" ") && !strings.HasPrefix(marked[0], "▸ "+tt.want+" ") {
+				t.Errorf("the marker is on the wrong row: %q, want %q", marked[0], tt.want)
+			}
+		})
+	}
+}
+
+// TestBranchPickerWindowsALongList is the @UI Patterns select-picker
+// exception, tested: a fixed number of rows whatever the repository holds, the
+// cursor always inside the window, and the hidden count stated rather than
+// implied.
+func TestBranchPickerWindowsALongList(t *testing.T) {
+	options := make([]string, 40)
+	for i := range options {
+		options[i] = fmt.Sprintf("branch-%02d", i)
+	}
+
+	for _, cursor := range []int{0, 1, 6, 7, 20, 38, 39} {
+		t.Run(fmt.Sprintf("cursor %d", cursor), func(t *testing.T) {
+			rows := strings.Split(
+				renderBranchPickerBody(options, "branch-00", cursor, branchPickerRows), "\n")
+
+			// The box does not grow: branchPickerRows options plus the one
+			// "… N more" line, at every cursor position.
+			if len(rows) != branchPickerRows+1 {
+				t.Fatalf("%d rows at cursor %d, want %d:\n%s",
+					len(rows), cursor, branchPickerRows+1, strings.Join(rows, "\n"))
+			}
+
+			cursorRows := 0
+			for _, row := range rows {
+				if strings.Contains(row, "▸") {
+					cursorRows++
+					if !strings.Contains(row, options[cursor]) {
+						t.Errorf("the cursor is on %q, want %q", row, options[cursor])
+					}
+				}
+			}
+			if cursorRows != 1 {
+				t.Errorf("%d rows carry the cursor, want 1:\n%s", cursorRows, strings.Join(rows, "\n"))
+			}
+
+			// The hidden count is explicit, and it is the real number.
+			want := fmt.Sprintf("… %d more", len(options)-branchPickerRows)
+			if last := rows[len(rows)-1]; !strings.Contains(last, want) {
+				t.Errorf("last row = %q, want it to state %q", last, want)
+			}
+		})
+	}
+}
+
+// A list that fits shows every option and claims nothing is hidden.
+func TestBranchPickerShortListHidesNothing(t *testing.T) {
+	body := renderBranchPickerBody([]string{"main", "wip"}, "main", 0, branchPickerRows)
+
+	if n := len(strings.Split(body, "\n")); n != 2 {
+		t.Errorf("%d rows for a 2-branch repository, want 2:\n%s", n, body)
+	}
+	if strings.Contains(body, "more") {
+		t.Errorf("a list that fits claims rows are hidden:\n%s", body)
+	}
+}
+
+// The body is never blank. openBranchModal routes an empty list to a notice,
+// so this is the guard behind that rather than a reachable state — a blank
+// content area is the silent empty state @UI Patterns forbids.
+func TestBranchPickerBodyIsNeverBlank(t *testing.T) {
+	if body := renderBranchPickerBody(nil, "", 0, branchPickerRows); strings.TrimSpace(body) == "" {
+		t.Error("an empty option list rendered a blank body")
+	}
+}
+
+// TestBranchPickerFitsAtEightyByTwentyFour is the sizing claim that can fail a
+// build: forty branches, the minimum terminal, and the whole box still on
+// screen with its hint bar and bottom border.
+func TestBranchPickerFitsAtEightyByTwentyFour(t *testing.T) {
+	branches := make([]string, 40)
+	for i := range branches {
+		branches[i] = fmt.Sprintf("feature/long-branch-name-%02d", i)
+	}
+
+	m := openPicker(t, pickerModel(domain.RepoState{
+		Head: domain.HeadOnBranch, Branch: branches[0], Branches: branches,
+	}))
+	m.width, m.height = 80, 24
+
+	out := ansi.Strip(m.View())
+	lines := strings.Split(out, "\n")
+
+	if len(lines) > 24 {
+		t.Errorf("the picker rendered %d lines at height 24", len(lines))
+	}
+	for i, line := range lines {
+		if w := lipgloss.Width(line); w > 80 {
+			t.Errorf("line %d is %d columns wide at width 80: %q", i, w, line)
+		}
+	}
+	// The two things truncation would take first, per the reason the picker
+	// windows rather than overflowing.
+	if !strings.Contains(out, "Esc/Cancel") {
+		t.Error("the hint bar was pushed off the screen")
+	}
+	if !strings.Contains(out, "╰") {
+		t.Error("the bottom border was pushed off the screen")
+	}
+}
+
+// ------------------------------------------------------------- the notices
+
+// noticeStates is every state that has no branch list. Each must open a modal
+// with a legible reason: @UI Patterns forbids a silent empty state, and a key
+// that does nothing at all is exactly that.
+func noticeStates() []struct {
+	name  string
+	entry *gitEntry
+	want  string
+} {
+	return []struct {
+		name  string
+		entry *gitEntry
+		want  string
+	}{
+		{name: "never asked", entry: nil, want: "git state"},
+		{name: "still loading", entry: &gitEntry{status: gitLoading}, want: "git state"},
+		{name: "not a repository", entry: &gitEntry{status: gitAbsent}, want: "not in a git repository"},
+		{name: "unreadable", entry: &gitEntry{status: gitUnknown}, want: "could not be read"},
+		{
+			name:  "no commits yet",
+			entry: &gitEntry{status: gitOK, state: domain.RepoState{Head: domain.HeadUnborn}},
+			want:  "no commits yet",
+		},
+	}
+}
+
+func TestEveryUnavailableStateOpensALegibleNotice(t *testing.T) {
+	seen := map[string]string{}
+
+	for _, tt := range noticeStates() {
+		t.Run(tt.name, func(t *testing.T) {
+			m := testModel()
+			if tt.entry != nil {
+				m = m.setGitEntry("alpha", *tt.entry)
+			}
+
+			opened, cmd := targetKeymap().dispatch("b")(m, "b")
+			if cmd != nil {
+				t.Error("`b` issued a command on a state with no branches")
+			}
+			if !opened.modal.active {
+				t.Fatal("`b` was a dead key; every unavailable state gets a reason")
+			}
+			if opened.modal.content != modalNotice {
+				t.Fatalf("content = %v, want a notice", opened.modal.content)
+			}
+
+			body := opened.renderModalBody()
+			if strings.TrimSpace(body) == "" {
+				t.Fatal("the notice body is blank")
+			}
+			if !strings.Contains(body, tt.want) {
+				t.Errorf("the notice does not explain itself: %q, want it to mention %q", body, tt.want)
+			}
+
+			// Info content: nothing to confirm, so the bar closes.
+			if got := ansi.Strip(opened.modal.keys.hintBar()); got != "Esc/Close" {
+				t.Errorf("notice hint bar = %q, want %q", got, "Esc/Close")
+			}
+
+			// It fits, untruncated, at the floor.
+			out := ansi.Strip(opened.View())
+			if n := len(strings.Split(out, "\n")); n > 24 {
+				t.Errorf("the notice rendered %d lines at height 24", n)
+			}
+			for i, line := range strings.Split(out, "\n") {
+				if w := lipgloss.Width(line); w > 80 {
+					t.Errorf("line %d is %d columns wide at width 80: %q", i, w, line)
+				}
+			}
+			if strings.Contains(body, "…") {
+				t.Errorf("the notice was truncated rather than wrapped: %q", body)
+			}
+
+			closed, cmd := press(t, opened, "esc")
+			if closed.modal.active {
+				t.Error("Esc left the notice open")
+			}
+			if cmd != nil {
+				t.Error("Esc issued a command while closing")
+			}
+
+			seen[tt.name] = strings.TrimSpace(body)
+		})
+	}
+
+	// Three different sentences, not one sentence three times: the user must
+	// be able to tell "no repository" from "unreadable" from "no commits".
+	for aName, a := range seen {
+		for bName, b := range seen {
+			// The two in-flight states are deliberately the same sentence —
+			// "no entry yet" and "read in flight" are the same fact.
+			if aName < bName && a == b && !(strings.Contains(a, "Still reading")) {
+				t.Errorf("%s and %s show the same sentence %q", aName, bName, a)
+			}
+		}
+	}
+}
+
+// ------------------------------------------------------------ opening it
+
+func TestPickerOpensOnTheCurrentBranch(t *testing.T) {
+	m := openPicker(t, pickerModel(domain.RepoState{
+		Head: domain.HeadOnBranch, Branch: "main", Branches: []string{"feat/api", "main", "wip"},
+	}))
+
+	if m.modal.input.cursor != 1 {
+		t.Errorf("cursor opened at %d, want 1 — the row for the current branch", m.modal.input.cursor)
+	}
+	if m.modal.title != "Switch branch" {
+		t.Errorf("modal title = %q", m.modal.title)
+	}
+	if m.modal.context != "alpha" {
+		t.Errorf("modal context = %q, want the project name", m.modal.context)
+	}
+}
+
+// A detached HEAD opens the picker normally — switching to a branch is a
+// legitimate escape from it, so nothing is disabled.
+func TestPickerOpensWhenDetached(t *testing.T) {
+	m := openPicker(t, pickerModel(domain.RepoState{
+		Head: domain.HeadDetached, Branches: []string{"main", "wip"},
+	}))
+
+	if m.modal.input.cursor != 0 {
+		t.Errorf("cursor opened at %d, want the top", m.modal.input.cursor)
+	}
+	if strings.Contains(m.renderModalBody(), "(current)") {
+		t.Error("a detached HEAD marked a row as current")
+	}
+}
+
+func TestBranchPickerHintBar(t *testing.T) {
+	// The AC's prescribed Enter/Confirm  Esc/Cancel, plus the navigation key
+	// @UI Patterns permits a picker to add.
+	want := "↑↓/Navigate  Enter/Confirm  Esc/Cancel"
+	if got := ansi.Strip(branchPickerKeymap().hintBar()); got != want {
+		t.Errorf("picker hint bar = %q, want %q", got, want)
+	}
+}
+
+func TestPickerNavigationStaysInBounds(t *testing.T) {
+	m := openPicker(t, pickerModel(domain.RepoState{
+		Head: domain.HeadOnBranch, Branch: "main", Branches: []string{"main", "wip"},
+	}))
+
+	for i := 0; i < 4; i++ {
+		m, _ = press(t, m, "up")
+	}
+	if m.modal.input.cursor != 0 {
+		t.Errorf("cursor walked above the first row: %d", m.modal.input.cursor)
+	}
+	for i := 0; i < 4; i++ {
+		m, _ = press(t, m, "down")
+	}
+	if m.modal.input.cursor != 1 {
+		t.Errorf("cursor walked past the last row: %d", m.modal.input.cursor)
+	}
+}
+
+func TestEscCancelsWithoutCheckingOut(t *testing.T) {
+	before := pickerModel(domain.RepoState{
+		Head: domain.HeadOnBranch, Branch: "main", Branches: []string{"main", "wip"},
+	})
+
+	m, cmd := press(t, openPicker(t, before), "esc")
+	if m.modal.active {
+		t.Error("Esc left the picker open")
+	}
+	if cmd != nil {
+		t.Error("Esc issued a command; cancelling runs nothing")
+	}
+	if m.targetCursor != before.targetCursor || m.view != before.view {
+		t.Error("Esc disturbed the underlying view")
+	}
+}
+
+// `b` inside an open modal is a no-op, like every other key the modal does not
+// bind. Without this the picker could open over the help overlay.
+func TestBInsideAnOpenModalIsANoOp(t *testing.T) {
+	opened, _ := targetKeymap().dispatch("?")(testModel(), "?")
+
+	updated, cmd := opened.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b")})
+	after := updated.(Model)
+
+	if cmd != nil {
+		t.Error("`b` issued a command through an open modal")
+	}
+	if after.modal.content != modalHelp {
+		t.Errorf("`b` changed the open modal's content to %v", after.modal.content)
+	}
+}
+
+// ------------------------------------------------- one read, one snapshot
+
+func TestOpeningThePickerSnapshotsTheRepoState(t *testing.T) {
+	state := domain.RepoState{
+		Head: domain.HeadOnBranch, Branch: "main", Dirty: true,
+		Branches: []string{"feature", "main"},
+	}
+
+	m := openPicker(t, pickerModel(state))
+
+	if m.modal.repo.Branch != state.Branch || !slices.Equal(m.modal.repo.Branches, state.Branches) {
+		t.Errorf("the modal snapshotted %+v, want %+v", m.modal.repo, state)
+	}
+	if !m.modal.repo.Dirty {
+		t.Error("the snapshot dropped the dirty flag; CheckoutBranch is validated against the whole state")
+	}
+}
+
+// TestAReadLandingMidModalDoesNotInvalidateAVisibleRow is why the snapshot is
+// the whole RepoState rather than the option list alone.
+//
+// A background read landing while the picker is up replaces the cache entry.
+// If the Enter handler validated against the cache, the user could select a
+// row that is on screen in front of them and be refused for a branch list they
+// cannot see — a narrow window, and unreproducible once it happens.
+func TestAReadLandingMidModalDoesNotInvalidateAVisibleRow(t *testing.T) {
+	m := openPicker(t, pickerModel(domain.RepoState{
+		Head: domain.HeadOnBranch, Branch: "main", Branches: []string{"feature", "main"},
+	}))
+
+	// A read lands: feature is gone from the repository's branch list.
+	m = m.applyGitState(gitStateMsg{
+		project: "alpha", gen: m.gitGen, status: gitOK,
+		state: domain.RepoState{Head: domain.HeadOnBranch, Branch: "main", Branches: []string{"main"}},
+	})
+	if slices.Contains(m.gitCache["alpha"].state.Branches, "feature") {
+		t.Fatal("the mid-modal read did not land; this test is not exercising the hazard")
+	}
+
+	// The user selects the row they can still see.
+	m, _ = press(t, m, "up")
+	if got := m.modal.repo.Branches[m.modal.input.cursor]; got != "feature" {
+		t.Fatalf("the cursor is on %q, want feature", got)
+	}
+
+	_, cmd := press(t, m, "enter")
+	for _, msg := range runCmd(cmd) {
+		if failed, ok := msg.(runFailedMsg); ok {
+			t.Fatalf("selecting a row that is on screen was refused: %v — "+
+				"the Enter handler read the cache instead of the snapshot", failed.err)
+		}
+	}
+
+	// Non-vacuity: the refusal path is live, so the assertion above is not
+	// passing because nothing can ever be refused.
+	proj, _ := m.currentProject()
+	msgs := runCmd(m.checkout(proj, "never-existed"))
+	if len(msgs) != 1 {
+		t.Fatalf("checkout of an unknown branch produced %d messages, want 1", len(msgs))
+	}
+	if _, ok := msgs[0].(runFailedMsg); !ok {
+		t.Errorf("a branch absent from the snapshot produced %T, want a refusal", msgs[0])
+	}
+}
+
+// A branch name too wide for the modal is ellipsised in the display, but the
+// checkout gets the real string: the snapshot holds it, and the rendered row is
+// never what gets passed on.
+func TestALongBranchNameIsEllipsisedButCheckedOutInFull(t *testing.T) {
+	long := "feature/" + strings.Repeat("very-long-", 8) + "name"
+
+	m := openPicker(t, pickerModel(domain.RepoState{
+		Head: domain.HeadOnBranch, Branch: "main", Branches: []string{long, "main"},
+	}))
+	m.width, m.height = 80, 24
+
+	if !strings.Contains(ansi.Strip(m.View()), "…") {
+		t.Error("an over-wide branch name was not ellipsised")
+	}
+
+	m, _ = press(t, m, "up")
+	if got := m.modal.repo.Branches[m.modal.input.cursor]; got != long {
+		t.Fatalf("the snapshot holds %q, want the full name", got)
+	}
+
+	// A refusal here would mean the truncated display string reached
+	// CheckoutBranch, which validates against the snapshot's real names.
+	_, cmd := press(t, m, "enter")
+	for _, msg := range runCmd(cmd) {
+		if failed, ok := msg.(runFailedMsg); ok {
+			t.Fatalf("the checkout was refused: %v — the display string reached the command", failed.err)
+		}
+	}
+}
+
+// ------------------------------------------------------- the return path
+
+// TestARefusedCheckoutDoesNotClaimTheNewBranch is the load-bearing test of
+// this feature.
+//
+// git refuses the checkout — a dirty tree it will not overwrite — so HEAD does
+// not move. The reader still answers main, because that is what the repository
+// still says. Nothing on screen may claim otherwise: not the header, not a
+// flash, not anything derived from the branch the user picked.
+func TestARefusedCheckoutDoesNotClaimTheNewBranch(t *testing.T) {
+	dirtyOnMain := domain.RepoState{
+		Head: domain.HeadOnBranch, Branch: "main", Dirty: true,
+		Branches: []string{"feature", "main"},
+	}
+
+	m := pickerModel(dirtyOnMain)
+	// The repository after the refused checkout: unchanged.
+	m.app = app.New(fakeScanner{}, fakeRunner{}, fakeGitReader{state: dirtyOnMain})
+
+	m = openPicker(t, m)
+	m, _ = press(t, m, "up")
+	if got := m.modal.repo.Branches[m.modal.input.cursor]; got != "feature" {
+		t.Fatalf("the cursor is on %q, want feature", got)
+	}
+
+	m, cmd := press(t, m, "enter")
+	if cmd == nil {
+		t.Fatal("Enter ran nothing")
+	}
+	if m.modal.active {
+		t.Error("Enter left the picker open behind the handover")
+	}
+
+	after := returnFromHandover(t, m, checkoutFinishedMsg{})
+
+	if got := header(after); !strings.Contains(got, "main ● dirty") {
+		t.Errorf("the header does not show the state that was read: %q", got)
+	}
+	// The whole screen, not just the header: a flash naming the branch would
+	// be the same lie one line lower.
+	if screen := ansi.Strip(after.View()); strings.Contains(screen, "feature") {
+		t.Errorf("the display names the branch the user selected after git refused to switch to it:\n%s", screen)
+	}
+	if after.flash != "" {
+		t.Errorf("a flash was set on return from a checkout: %q", after.flash)
+	}
+}
+
+// TestASuccessfulCheckoutShowsTheNewBranch is the twin the test above needs to
+// mean anything. Without it, a header that never updated at all would pass.
+func TestASuccessfulCheckoutShowsTheNewBranch(t *testing.T) {
+	before := domain.RepoState{
+		Head: domain.HeadOnBranch, Branch: "main",
+		Branches: []string{"feature", "main"},
+	}
+
+	m := pickerModel(before)
+	// The repository after the checkout succeeded: HEAD moved.
+	m.app = app.New(fakeScanner{}, fakeRunner{}, fakeGitReader{state: domain.RepoState{
+		Head: domain.HeadOnBranch, Branch: "feature",
+		Branches: []string{"feature", "main"},
+	}})
+
+	m = openPicker(t, m)
+	m, _ = press(t, m, "up")
+	m, cmd := press(t, m, "enter")
+	if cmd == nil {
+		t.Fatal("Enter ran nothing")
+	}
+
+	after := returnFromHandover(t, m, checkoutFinishedMsg{})
+
+	if got := header(after); !strings.Contains(got, "feature ✓ clean") {
+		t.Errorf("the header does not show the branch that was read: %q", got)
+	}
+}
+
+// TestCheckoutFinishedMsgCarriesNothing makes the load-bearing property
+// structural rather than sampled.
+//
+// TestARefusedCheckoutDoesNotClaimTheNewBranch drives the return path with a
+// message it constructs itself, so it can only observe what the *model* does
+// with that message — a field added here and rendered from would be invisible
+// to it if the test happened to leave the field zero. A message type with no
+// fields cannot carry the branch, the exit code, or anything else derived from
+// the checkout, whatever a later case does with it.
+//
+// If a future feature genuinely needs something back from a checkout, this is
+// the test to argue with first: the reason it is empty is that everything the
+// display says about the branch must come from a read.
+func TestCheckoutFinishedMsgCarriesNothing(t *testing.T) {
+	if n := reflect.TypeOf(checkoutFinishedMsg{}).NumField(); n != 0 {
+		t.Errorf("checkoutFinishedMsg has %d fields; it must carry nothing back from the "+
+			"handover, so that no code path can write the selected branch into the display", n)
+	}
+}
+
+// The return carries nothing into the model: no flash, no lastRun, no record
+// of what was selected.
+func TestCheckoutFinishedSaysNothing(t *testing.T) {
+	m := pickerModel(domain.RepoState{
+		Head: domain.HeadOnBranch, Branch: "main", Branches: []string{"main"},
+	})
+	m.flash = "an earlier message"
+
+	after, cmd := m.dispatch(checkoutFinishedMsg{})
+
+	if after.flash != "an earlier message" {
+		t.Errorf("checkoutFinishedMsg touched the flash: %q", after.flash)
+	}
+	if after.lastRun != nil {
+		t.Errorf("checkoutFinishedMsg recorded a run result: %+v", after.lastRun)
+	}
+	// Compared against the message tea.EnterAltScreen itself produces: the
+	// type is unexported, and a bare cmd != nil would pass for any other
+	// command the case might return instead.
+	if got := runCmd(cmd); len(got) != 1 || got[0] != tea.EnterAltScreen() {
+		t.Errorf("checkoutFinishedMsg produced %v, want tea.EnterAltScreen — the handover left "+
+			"the alt screen and something has to re-enter it", got)
+	}
+}
+
+// checkoutStatus quotes git rather than narrating over it, and names no
+// branch on either outcome.
+func TestCheckoutStatusNamesNoBranch(t *testing.T) {
+	ok := checkoutStatus(0, nil, 0)
+	failed := checkoutStatus(1, fmt.Errorf("exit status 1"), 0)
+
+	if strings.Contains(ok, "branch '") || strings.Contains(failed, "branch '") {
+		t.Errorf("checkoutStatus named a branch: %q / %q", ok, failed)
+	}
+	if ok == failed {
+		t.Error("checkoutStatus reports success and failure identically")
+	}
+	if !strings.Contains(failed, "exit status 1") {
+		t.Errorf("the failure line drops git's own error: %q", failed)
+	}
+}

--- a/internal/ui/tui/model.go
+++ b/internal/ui/tui/model.go
@@ -86,6 +86,12 @@ type gitPullFinishedMsg struct {
 	err          error
 }
 
+// checkoutFinishedMsg says a checkout handover returned. It carries nothing,
+// and that is the design: neither the exit code nor the selected branch is a
+// reading of where HEAD points, so neither may reach the display. See its case
+// in dispatch.
+type checkoutFinishedMsg struct{}
+
 func (m Model) Init() tea.Cmd {
 	return nil
 }
@@ -171,6 +177,18 @@ func (m Model) dispatch(msg tea.Msg) (Model, tea.Cmd) {
 		if m.view == viewTargets {
 			m.targetCursor = 0
 		}
+		return m, tea.EnterAltScreen
+
+	case checkoutFinishedMsg:
+		// Nothing is recorded and no flash is set, on either outcome.
+		//
+		// The hazard this case exists to avoid is writing anything here at
+		// all: a flash naming the selected branch, or a success line derived
+		// from the exit code, would be a claim about what is checked out made
+		// by code that never read the repository. A refused checkout would
+		// then announce the branch it failed to switch to. What the header
+		// shows next comes from the fresh RepoState read Update's handover
+		// unwrap has already issued, and from nothing else.
 		return m, tea.EnterAltScreen
 
 	case execFinishedMsg:

--- a/internal/ui/tui/model_test.go
+++ b/internal/ui/tui/model_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/Gaetan-Jaminon/mkx/internal/app"
@@ -118,7 +119,7 @@ func TestHintBarsMatchTheBaselineFormats(t *testing.T) {
 		{
 			name: "targets",
 			k:    targetKeymap(),
-			want: "↑↓/Navigate  //Search  Enter/Run  g/Pull  R/Readme  Esc/Back  ?/Help",
+			want: "↑↓/Navigate  //Search  Enter/Run  b/Branch  g/Pull  R/Readme  Esc/Back  ?/Help",
 		},
 	}
 
@@ -128,6 +129,38 @@ func TestHintBarsMatchTheBaselineFormats(t *testing.T) {
 				t.Errorf("hintBar() = %q\nwant           %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestTargetHintBarFitsOnOneLine is a width guard, not a formatting
+// preference.
+//
+// styles.HintBar is Width(80) with Padding(0,1), so it has 78 content columns —
+// and it is fixed at 80 regardless of the terminal, so the ceiling holds on a
+// 200-column terminal too. With b/Branch the target bar is exactly 78 of 78. At
+// 79 lipgloss word-wraps rather than truncating, the bar silently becomes two
+// rows, and every height-sensitive test in this suite breaks with no line in
+// the failure pointing at the cause.
+//
+// So the next binding added to this view fails here instead, loudly, saying
+// what to do about it. The underlying fixed width is TAE-60's to fix; this test
+// is what TAE-60 replaces, not what it deletes.
+func TestTargetHintBarFitsOnOneLine(t *testing.T) {
+	const barContentWidth = 78
+
+	if w := lipgloss.Width(ansi.Strip(targetKeymap().hintBar())); w > barContentWidth {
+		t.Errorf("the target hint bar is %d columns wide, and styles.HintBar has only %d; "+
+			"it will wrap to a second line. Shorten a label, drop a binding from the bar, "+
+			"or fix the fixed width (TAE-60) — do not just raise this number",
+			w, barContentWidth)
+	}
+
+	// The claim itself, through the real style rather than through arithmetic
+	// about it: one rendered line at 80 columns.
+	m := testModel()
+	m.width = 80
+	if n := strings.Count(m.renderHintBar(targetKeymap()), "\n"); n != 0 {
+		t.Errorf("the target hint bar rendered on %d lines at width 80, want 1", n+1)
 	}
 }
 

--- a/scripts/demo-git.sh
+++ b/scripts/demo-git.sh
@@ -19,8 +19,13 @@ WORK="$(mktemp -d -t mkx-git-demo-XXXXXX)"
 
 # Local to this script, so the demo repositories do not depend on the machine's
 # git identity and do not inherit a global hooks or template directory.
+#
+# -b main for the same reason: the checklist below names `main` in what the
+# header must read, and the conflict fixture checks out `main` by name. Without
+# it the branch is whatever init.defaultBranch happens to be on this machine,
+# and the checklist quietly stops matching the screen.
 git_init() {
-	git init -q "$1"
+	git init -q -b main "$1"
 	git -C "$1" config user.email "demo@example.invalid"
 	git -C "$1" config user.name "mkx demo"
 	git -C "$1" config commit.gpgsign false
@@ -64,6 +69,14 @@ readme "$WORK/clean"
 git_init "$WORK/clean"
 git -C "$WORK/clean" add -A
 git -C "$WORK/clean" commit -qm "initial"
+# Branches to switch between, and enough of them to overflow the picker's
+# window: it shows seven rows, so nine branches means two are hidden and the
+# "… 2 more" line has to appear. A repository with three branches would leave
+# the windowing entirely unexercised by eye.
+for branch in feat/api release/2.1 wip/spike hotfix/urgent docs/readme \
+	chore/deps experiment/one experiment/two; do
+	git -C "$WORK/clean" branch "$branch"
+done
 
 # dirty — the same, plus an untracked file. Untracked rather than modified on
 # purpose: `git status --porcelain` reports it, and a reader that only looked at
@@ -75,6 +88,30 @@ git_init "$WORK/dirty"
 git -C "$WORK/dirty" add -A
 git -C "$WORK/dirty" commit -qm "initial"
 echo "scratch" >"$WORK/dirty/untracked.txt"
+
+# conflict — the fixture for the step that matters: a checkout git will REFUSE.
+#
+# The `dirty` project above will not do. It is dirtied with an *untracked* file,
+# and git switches branches perfectly happily with untracked files present — a
+# refusal step built on it is a step that cannot fail, which is worse than no
+# step at all.
+#
+# To make git actually refuse, the working tree needs an uncommitted
+# modification to a file whose content DIFFERS between the two branches. Then
+# switching would have to overwrite the edit, and git stops with "Your local
+# changes to the following files would be overwritten by checkout".
+mkdir -p "$WORK/conflict"
+makefile "$WORK/conflict"
+readme "$WORK/conflict"
+git_init "$WORK/conflict"
+printf 'the main version\n' >"$WORK/conflict/shared.txt"
+git -C "$WORK/conflict" add -A
+git -C "$WORK/conflict" commit -qm "initial"
+git -C "$WORK/conflict" checkout -q -b other
+printf 'the other version\n' >"$WORK/conflict/shared.txt"
+git -C "$WORK/conflict" commit -qam "diverge shared.txt"
+git -C "$WORK/conflict" checkout -q main
+printf 'an uncommitted local edit\n' >"$WORK/conflict/shared.txt"
 
 # detached — HEAD on a commit rather than a branch. `git rev-parse
 # --abbrev-ref HEAD` prints the literal "HEAD" here, exit 0.
@@ -119,6 +156,7 @@ Demo workspace: $WORK
 Enter each project (↑↓ then Enter) and check the header segment:
 
   clean       main ✓ clean        (green)
+  conflict    main ● dirty        (yellow)
   detached    detached ✓ clean    (yellow)
   dirty       main ● dirty        (yellow)
   norepo      no repo             (dimmed)
@@ -157,6 +195,45 @@ Then confirm, in that order:
   5. Caching. Enter 'clean', Esc, enter it again — the header shows its
      value immediately with no "…" flicker, because the entry is cached.
      After step 3's re-read, the brief "…" is visible again.
+
+BRANCH SWITCHING (b). Five steps; the second is the one that matters.
+
+  1. Enter 'clean' and press b. The picker lists the local branches, 'main'
+     carries (current), and the cursor starts on it. Nine branches, seven
+     rows, so the last line reads "… 2 more" — the box does not grow and
+     the hint bar and bottom border are still there. Select another branch
+     and press Enter:
+
+       git's own output appears in the terminal
+       Enter                →  back to mkx
+       header reads            the branch you selected
+
+  2. THE ONE THAT MATTERS. Enter 'conflict' — header reads main ● dirty.
+     Press b, select 'other', press Enter.
+
+       git REFUSES, in its own words:
+         "Your local changes to the following files would be overwritten
+          by checkout: shared.txt"
+
+       Enter                →  back to mkx
+       header MUST still read  main ● dirty
+
+     If the header reads 'other', the TUI has claimed a branch that was
+     never checked out. That is the worst outcome this feature can produce
+     and the branch is not shippable — stop and report it rather than
+     working around it. Nothing on screen may name the branch you selected:
+     not the header, not a flash message.
+
+  3. Enter 'detached' and press b. The picker opens normally and NO row is
+     marked (current) — a detached HEAD is on no branch. Select one and it
+     is a legitimate escape: the header comes back naming that branch.
+
+  4. Enter 'norepo' and press b. A notice modal, reading "not in a git
+     repository". Esc closes it. The key is never dead.
+
+  5. Enter 'unborn' and press b — "no commits yet". Enter 'broken' and
+     press b — "could not be read". Together with step 4 that is three
+     visibly different sentences for three different reasons.
 
 Run it with:
 


### PR DESCRIPTION
Closes [TAE-59](https://linear.app/taelron/issue/TAE-59/branch-switching-picker-modal-and-checkout-handover). The approved architect plan lives as a comment on that issue, with a revision block recording what changed after review; this PR implements it without deviation.

`b` on the target view opens a branch picker in [TAE-54](https://linear.app/taelron/issue/TAE-54/modal-overlay-frame-and-help-overlay-move-readme-off)'s modal frame. Selecting a branch runs `git checkout <branch>` through full terminal handover.

## The load-bearing property

**Nothing in the TUI ever names a branch it did not just read.**

The header segment is the only claim about what is checked out, and it comes from a fresh `RepoState` read issued by the invalidation path — never from the checkout's exit code, never from the branch the user selected. `checkoutFinishedMsg` is an empty struct, so no code path *can* carry either back into the model.

That is pinned three ways rather than asserted once:

- `TestARefusedCheckoutDoesNotClaimTheNewBranch` — the cache says `main ● dirty`, the picker selects `feature`, the reader still answers `main`. The header must show `main` and the whole screen must not contain `feature`.
- `TestASuccessfulCheckoutShowsTheNewBranch` — the same path with the reader answering `feature`. Without this twin, a header that never updated at all would pass the test above.
- `TestCheckoutFinishedMsgCarriesNothing` — reflection over the message type. The round-trip test constructs its own message, so it can only observe what the model does with the message it was handed; a field added later and rendered from would be invisible to it. A struct with no fields cannot carry the branch whatever a later case does.

## One read, one snapshot

`modalState` carries the whole `domain.RepoState`, snapshotted when the modal opens. The rows, the `(current)` marker and `CheckoutBranch`'s validation all read that one value; `m.gitCache` is not consulted at selection time.

Without it, a background read landing while the picker is up replaces the cache entry, and the user selects a row that is on screen in front of them and gets refused for a branch list they cannot see — a narrow window, and unreproducible once it happens. `TestAReadLandingMidModalDoesNotInvalidateAVisibleRow` drives exactly that sequence, and carries its own non-vacuity check so it cannot pass by nothing ever being refusable.

The guarantee is internal consistency, not currency: a branch deleted on disk while the modal is open is git's refusal to report, per ADR-M003, not MkX's to pre-empt.

## Against the acceptance criteria

| AC | Where |
|---|---|
| A key on the target view opens a branch picker in the modal frame, with the prescribed hint bar | `b` in `targetKeymap()`; bar is `↑↓/Navigate  Enter/Confirm  Esc/Cancel` |
| The picker lists local branches with the current one marked | `renderBranchPickerBody`; string equality, so `main` / `main-2` / `mainline` marks exactly one |
| Selecting a branch runs `git checkout` via `tea.Exec` handover | `checkout()` → the shared `handover()` |
| **No pre-validation** — no dirty refusal, no stash, no `--force` | `app.CheckoutBranch` validates its *argument* only; a dirty `RepoState` still yields a command |
| app returns `domain.Command`, `ui/tui` executes it | `app.CheckoutBranch` → `ui/tui`'s `checkout()` |
| On return RepoState is re-read and the display reflects it, including when the checkout failed | the existing `handoverDone` unwrap; nothing new written for it |
| Unavailable, with a legible reason, for a Project with no RepoState | five notice states, all worded differently |
| Registered once in the view's keymap; hint bar and help follow as projections | one `binding` in `keymap_views.go` |

## Notes

**The checkout routes through the shared `handover()`.** The package still has exactly two `tea.Exec` sites, so `handover_guard_test.go` needed no change and its `execSites < 2` non-vacuity floor stays correct. The AST guard is satisfied by construction, not worked around.

**A long branch list windows** inside a fixed-height box with an explicit `… N more`, under the select-picker exception @UI Patterns gained on 2026-08-02. The alternative is not a taller box: `buildModalBox` has no height clamp and `splice` silently drops overflowing lines, so a thirty-branch repository loses its hint bar and bottom border with no signal. Sabotaged to confirm — removing the windowing fails `TestBranchPickerFitsAtEightyByTwentyFour` on exactly those two symptoms.

**The target hint bar is now 78 of the 78 columns `styles.HintBar` allows.** At 79 lipgloss word-wraps rather than truncating, the bar silently becomes two rows, and every height-sensitive test in the suite breaks with nothing pointing at the cause. `TestTargetHintBarFitsOnOneLine` makes the next binding added to this view fail loudly instead. The fixed `Width(80)` underneath is [TAE-60](https://linear.app/taelron/issue/TAE-60/hint-bar-is-capped-at-a-fixed-80-columns)'s to fix — that issue replaces this test, it does not delete it.

**`filtered[T]` stays out**, per the issue's own conditional. The helper matches a `[]string` for free; the plumbing does not — `handleKey`'s tier 1 returns unconditionally for a modal, so the modal path has no rune-capture tier to hang a filter on.

## Verification handoff

All targets exist. Run top to bottom.

| # | Command | Purpose | Expected |
|---|---|---|---|
| 1 | `make build` | Compiles. | Binary written, no other output. |
| 2 | `make test` | Full suite. | All packages `ok`. |
| 3 | `make verify` | **The golden must not move.** | `PASS`, and `git status testdata/` stays clean. This feature touches `ui/tui`, `app` and `domain` but not discovery — a diff here means something leaked into discovery and is a defect, not a rebaseline. |
| 4 | `make verify-tui` | The picker, notices, windowing, snapshot and both round-trip tests, by name. | `PASS`. Read the `-v` names: `TestARefusedCheckoutDoesNotClaimTheNewBranch` and `TestASuccessfulCheckoutShowsTheNewBranch` must **both** appear and both pass. |
| 5 | `make verify-gitx` | The adapter was not disturbed. | `PASS`, unchanged. Spawns no git process. |
| 6 | `make verify-guards` | The golden guards still fail on a sabotaged copy. | `All guards tripped as required.` Never touches this tree. |
| 7 | `make tidy-check` | No dependency added. | Clean `git diff` on `go.mod` / `go.sum`. |
| 8 | `make demo-git` | Builds the visual workspace and prints the checklist. | A workspace path plus the checklist below. |

### Step 8 — the visual sequence

`make demo-git` prints the full checklist; it is reproduced here so the merge gate is readable without running it first. Run mkx in the printed workspace.

1. **`clean` → `b`.** The picker lists the branches, `main` carries `(current)`, the cursor starts on it. Nine branches over a seven-row window, so the last line reads `… 2 more` and the hint bar and bottom border are still on screen. Select another branch → git's output in the terminal → Enter → **the header reads the new branch**.
2. **`conflict` → `b` → select `other`. This is the one that matters.** git must refuse **in its own words** — `Your local changes to the following files would be overwritten by checkout: shared.txt`. Enter → **the header must still read `main ● dirty`**. If it reads `other`, the feature has produced the worst outcome it can and the branch is not shippable.
3. **`detached` → `b`.** The picker opens, **no row is marked current**, and selecting one is a legitimate escape to a branch.
4. **`norepo` → `b`.** A notice modal, *not in a git repository*. `Esc` closes it.
5. **`unborn` → `b`** — *no commits yet*. **`broken` → `b`** — *could not be read*. Three visibly different sentences with step 4; no dead key anywhere.

`demo-git.sh` is extended, not replaced — `make demo-git` stays the single entry point. Two additions: local branches in `clean`, and a new `conflict` project. **The existing `dirty` project could not carry step 2**: it is dirtied with an *untracked* file, and git switches branches happily with untracked files present, so a refusal step built on it is a step that cannot fail. `conflict` has `shared.txt` differing between `main` and `other` with an uncommitted edit in the tree, which is what makes git actually refuse. Confirmed by hand against git 2.47.3: `conflict` refuses with exit 1 and HEAD stays on `main`; `dirty` switches without complaint.

### What was already run

Every target above was run on this branch, and again from a **fresh clone of the pushed branch** — local green is not evidence that what was committed is green. Steps 1 and 2 of the visual sequence were additionally driven end to end against the real `gitx` adapter and the real demo repositories, running the actual `domain.Command` the app returns:

```
conflict:  BEFORE header: main ● dirty
           ARGV [git checkout other]
           git: error: Your local changes ... would be overwritten by checkout: shared.txt
                (exit status 1)
           AFTER  header: main ● dirty     flash: ""
clean:     BEFORE header: main ✓ clean
           ARGV [git checkout feat/api]
           git: Switched to branch 'feat/api'
           AFTER  header: feat/api ✓ clean flash: ""
```

The harness that produced this was a scratch file and is not committed — it is reported as evidence, and the human-run visual sequence remains the merge gate.

Five deliberate sabotages were run against the new tests to confirm they can fail, rather than trusting a green run: reading the cache instead of the snapshot, naming the selected branch on return, removing the windowing, and marking the current branch by prefix and by containment. The first three were caught. **The last two were not** — the marker test case had picked `main-2` as the current branch, where a prefix match happens to give the right answer. That case was rewritten to make the current branch the *shortest* name, and both sabotages now fail it.

**Three `code-reviewer` passes** (simplicity/DRY, bugs/correctness, conventions & ADR adherence) ran in-session. Two returned no findings. The third found `TestCheckoutFinishedSaysNothing` asserting only `cmd != nil` while its failure message claimed the alt screen was re-entered — weaker than its own name. Fixed to compare against the message `tea.EnterAltScreen` produces, and confirmed to fail when the case returns a different command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
