### PR TITLE
Batched key input: a batch may only ever open a text sink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
   # Nothing in `go test ./...` touches the guard script, so unlike `make verify`
   # this proof is not transitive. If it does not run here, it runs only when
   # someone remembers.
+  #
+  # The same is true of every sabotage script, so they share this job rather
+  # than each getting one: they are all ubuntu-only, all off the critical path,
+  # and all proving the same class of claim — that a test which is supposed to
+  # catch something actually goes red when that something is broken.
   guards:
     runs-on: ubuntu-latest
     steps:
@@ -38,3 +43,9 @@ jobs:
         with:
           go-version-file: go.mod
       - run: make verify-guards
+      # TAE-61's batch guards. The deliverable there is behaviour that must not
+      # happen — no pasted or replayed input may fire a checkout, a pull or a
+      # target run — so a green suite shows only that nothing tripped. This
+      # removes each of handleKey's two guards in a throwaway copy and fails
+      # unless the batch tests go red by name.
+      - run: make verify-batch-guard

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY   := mkx
 FIXTURES := testdata/fixtures
 
-.PHONY: build test verify verify-parser verify-gitx verify-tui verify-guards rebaseline-golden tidy-check run demo-git
+.PHONY: build test verify verify-parser verify-gitx verify-tui verify-guards verify-batch-guard rebaseline-golden tidy-check run demo-git
 
 build: ## Compile the mkx binary
 	go build -o $(BINARY) ./cmd/mkx
@@ -27,6 +27,9 @@ verify-tui: ## Run the TUI keymap, modal and overlay tests by name
 
 verify-guards: ## Prove the golden guards fail — sabotages a throwaway copy, never this tree
 	./scripts/verify-oracle-guards.sh
+
+verify-batch-guard: ## Prove the batched-input tests fail when either guard is removed
+	./scripts/verify-batch-guard.sh
 
 rebaseline-golden: ## Re-anchor the golden to current behaviour — reviewed behaviour changes only
 	go test -count=1 -v -run '^TestCharacterization$$' ./internal/app/ -rebaseline

--- a/internal/ui/tui/batch.go
+++ b/internal/ui/tui/batch.go
@@ -1,0 +1,124 @@
+package tui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Batched key input: runes that arrived in a single terminal read.
+//
+// The rule, stated once and enforced in one place:
+//
+//	A batch may only ever open a text sink. Its first rune only is looked up
+//	in the active keymap, and the handler runs only if that binding declares
+//	that it opens a text sink. The remaining runes then go to the sink as
+//	literal text. A batch whose first rune opens no sink fires nothing and
+//	sets a flash saying so. A batch never returns a tea.Cmd. While a modal is
+//	up, a batch is a no-op.
+//
+// There are two batch shapes and both are live:
+//
+//	bracketed  a real paste into a bracketed-paste terminal. Paste is true,
+//	           and the batch carries every rune between the markers — \r, \n,
+//	           tabs and spaces included, at any length, including one.
+//	raw        a multiplexer replaying buffered bytes. Paste is false, and the
+//	           batch is a contiguous run of printable non-space runes, because
+//	           bubbletea's detectOneMsg breaks the run on a control character
+//	           or a space.
+//
+// The raw shape is why this file exists at all rather than trusting the
+// library. Key.String() brackets a pasted batch, so `[/boot]` matches no
+// binding and a bracketed paste can never activate a shortcut. A raw batch is
+// not bracketed: its String() is the literal text, so a replay spelling
+// `enter`, `esc`, `up`, `down` or `ctrl+c` *is* that key to whole-string
+// dispatch. In the branch picker that means a replayed `enter` performs a
+// checkout. Structurally keeping a batch away from dispatch is what closes
+// that, and it closes it for every binding at once rather than for a list of
+// them that a future binding could fall off.
+//
+// Known and not closed: a raw replay of "make\n" arrives as KeyRunes("make")
+// and then a separate KeyEnter. The batch becomes filter text; the bare Enter
+// is indistinguishable from a real keypress and still runs the selected
+// target. Bracketed paste — the default, and what Zellij forwards — prevents
+// it, because there the \r stays a rune inside the batch. Closing the residual
+// case needs a timing heuristic that would misfire on a fast typist and cannot
+// be tested without injecting a clock.
+
+// isBatch reports whether msg carries runes that arrived together.
+//
+// The discriminator is Paste *or* length, not length alone: a bracketed paste
+// of a single `b` is still pasted input, and length alone would let it open
+// the branch picker. The !Alt term mirrors the filter capture — an
+// alt-modified rune is a chord, and the library never emits more than one rune
+// after Alt.
+func isBatch(msg tea.KeyMsg) bool {
+	return msg.Type == tea.KeyRunes && !msg.Alt && (msg.Paste || len(msg.Runes) > 1)
+}
+
+// dispatchBatch is the whole of what a batch may do.
+//
+// Tier 3 in handleKey is its only caller today. Tier 1 does not reach here at
+// all: with a modal up a batch is a hard no-op, because no modal has a text
+// field for the remaining runes to land in.
+//
+// It still takes the keymap as a parameter rather than reading m.viewKeymap()
+// itself, and that is the one line of preparation this file makes for a modal
+// that grows one. Such a modal would tick opensTextSink on its own binding and
+// point tier 1 here; nothing in this function would change. Reading the view
+// keymap internally would hard-wire the assumption that only a view can hold a
+// sink, which is the assumption most likely to stop being true.
+func (m Model) dispatchBatch(k keymap, msg tea.KeyMsg) (Model, tea.Cmd) {
+	if len(msg.Runes) == 0 {
+		// An empty bracketed paste — an empty clipboard. Nothing to lead with,
+		// and the lead-rune index below would panic.
+		return m, nil
+	}
+
+	lead := string(msg.Runes[0])
+
+	b, found := k.bindingFor(lead)
+	if !found || !b.opensTextSink {
+		m.flash = k.ignoredBatchFlash()
+		return m, nil
+	}
+
+	// The returned command is deliberately discarded, and that is the third of
+	// the three layers that make "no batch fires a checkout, a pull, or a
+	// target run" a property of this signature rather than of a review: even a
+	// binding wrongly marked as a sink cannot hand the terminal to a process.
+	//
+	// It has a cost worth writing down. A future opensTextSink binding whose
+	// handler legitimately needs to return a command — a sink that must fetch
+	// something before it can accept text — would have that command silently
+	// dropped. Today `/` sets state and returns nil, so the discard costs
+	// nothing. Whoever adds the second text sink revisits this on purpose
+	// rather than discovering it as a bug.
+	m, _ = b.handler(m, lead)
+
+	// The binding claimed to open a sink; this is where that claim is checked.
+	// A binding that says it opens one and does not is a registry bug, and
+	// without this the remaining runes would go nowhere with no signal.
+	//
+	// This is the one line that knows the sink *is* filter mode. With exactly
+	// one sink in the product a generic sink interface would be speculative;
+	// the second sink makes this the place to generalise.
+	if !m.filter.active {
+		m.flash = k.ignoredBatchFlash()
+		return m, nil
+	}
+
+	return m.appendFilterRunes(msg.Runes[1:]), nil
+}
+
+// ignoredBatchFlash is what a view says when it drops a batch, derived from the
+// registry rather than written per view.
+//
+// A view that declares a text sink names its key, so the target view reads
+// "Pasted input ignored — press / to filter" and the project view, which binds
+// no `/`, reads "Pasted input ignored". Neither view holds a line of
+// batch-specific code.
+func (k keymap) ignoredBatchFlash() string {
+	if b, ok := k.textSink(); ok {
+		return "Pasted input ignored — press " + b.display + " to filter"
+	}
+	return "Pasted input ignored"
+}

--- a/internal/ui/tui/batch_test.go
+++ b/internal/ui/tui/batch_test.go
@@ -1,0 +1,494 @@
+package tui
+
+// The batched-input tests.
+//
+// Every behavioural test here drives Model.Update with a tea.KeyMsg literal
+// carrying all of its runes at once, written inline. That is deliberate and it
+// is the point: this defect was found by a harness that batched where a human
+// would not, and a helper that builds a key per rune cannot reproduce it. There
+// is no helper in this file, and the literals stay literals.
+//
+// What is asserted is almost entirely behaviour that must *not* happen — no
+// checkout, no pull, no target run, no quit — so each test also pins the
+// positive half where there is one, to keep "nothing happened" from passing for
+// the wrong reason.
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/app"
+	"github.com/Gaetan-Jaminon/mkx/internal/domain"
+)
+
+// ------------------------------------------------------- the discriminator
+
+// TestIsBatch pins the discriminator itself, including the case that rules out
+// the simpler rule: a bracketed paste of a single rune is a batch. Length alone
+// would let a pasted `b` open the branch picker.
+func TestIsBatch(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  tea.KeyMsg
+		want bool
+	}{
+		{name: "bracketed paste, many runes",
+			msg:  tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/boot"), Paste: true},
+			want: true},
+		{name: "bracketed paste, one rune",
+			msg:  tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b"), Paste: true},
+			want: true},
+		{name: "bracketed paste carrying a carriage return",
+			msg:  tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("make\r"), Paste: true},
+			want: true},
+		{name: "raw replay, many runes",
+			msg:  tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("enter")},
+			want: true},
+		{name: "a typed rune",
+			msg:  tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b")},
+			want: false},
+		{name: "enter",
+			msg:  tea.KeyMsg{Type: tea.KeyEnter},
+			want: false},
+		{name: "space",
+			msg:  tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}},
+			want: false},
+		{name: "alt-modified rune",
+			msg:  tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("g"), Alt: true},
+			want: false},
+		{name: "alt-modified multi-rune, which the library never emits",
+			msg:  tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("gg"), Alt: true},
+			want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBatch(tt.msg); got != tt.want {
+				t.Errorf("isBatch(%+v) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+// ------------------------------------------------------- the sink that opens
+
+// TestPastedFilterStringOpensFilterModeAndTypesTheRest is the headline
+// criterion: pasting `/boot` leaves filter mode active with `boot` typed.
+//
+// [red] before the fix: Key.String() is "[/boot]" for a bracketed paste, which
+// matches no binding, so dispatch discarded it.
+func TestPastedFilterStringOpensFilterModeAndTypesTheRest(t *testing.T) {
+	m := filterModel()
+
+	after, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/boot"), Paste: true})
+	got, ok := after.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, not a Model", after)
+	}
+
+	if !got.filter.active {
+		t.Error("a pasted `/boot` did not activate filter mode")
+	}
+	if got.filter.text != "boot" {
+		t.Errorf("filter text = %q, want %q", got.filter.text, "boot")
+	}
+	if cmd != nil {
+		t.Error("a batch issued a command; a batch never returns one")
+	}
+}
+
+// TestReplayedFilterStringDoesTheSame is the same paste as it arrives from a
+// multiplexer replaying buffered bytes: no bracketing, so Paste is false.
+//
+// [red] before the fix: String() is the literal "/boot", which matches no
+// binding either.
+func TestReplayedFilterStringDoesTheSame(t *testing.T) {
+	m := filterModel()
+
+	after, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/boot")})
+	got, ok := after.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, not a Model", after)
+	}
+
+	if !got.filter.active {
+		t.Error("a replayed `/boot` did not activate filter mode")
+	}
+	if got.filter.text != "boot" {
+		t.Errorf("filter text = %q, want %q", got.filter.text, "boot")
+	}
+	if cmd != nil {
+		t.Error("a batch issued a command; a batch never returns one")
+	}
+}
+
+// TestAnEmptyPasteIsASilentNoOp covers an empty clipboard, which arrives as a
+// bracketed paste carrying no runes. There is no lead rune to look up and no
+// batch to ignore, so it is silent rather than a flash — and the guard that
+// makes it silent is also what keeps the lead-rune index from panicking.
+func TestAnEmptyPasteIsASilentNoOp(t *testing.T) {
+	m := filterModel()
+
+	after, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(""), Paste: true})
+	got, ok := after.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, not a Model", after)
+	}
+
+	if cmd != nil {
+		t.Error("an empty paste issued a command")
+	}
+	if got.flash != "" {
+		t.Errorf("an empty paste set the flash %q; there was no input to ignore", got.flash)
+	}
+	if got.filter != (filterState{}) {
+		t.Errorf("an empty paste changed the filter to %+v", got.filter)
+	}
+}
+
+// ---------------------------------------------- the five colliding key names
+
+// TestBatchSpellingEnterDoesNotRunATarget is the collision found during
+// planning, and it is the worst of them: a raw batch's String() is its literal
+// text, so a replay spelling `enter` *is* Enter to whole-string dispatch.
+//
+// [red] before the fix, and loudly: the selected target runs.
+func TestBatchSpellingEnterDoesNotRunATarget(t *testing.T) {
+	var ran string
+	m := filterModel()
+	m.app = app.New(fakeScanner{}, recordingRunner{ran: &ran}, fakeGitReader{})
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("enter")})
+
+	if ran != "" {
+		t.Errorf("a batch spelling `enter` ran the target %q", ran)
+	}
+	if cmd != nil {
+		t.Error("a batch spelling `enter` issued a command")
+	}
+}
+
+// TestBatchSpellingEnterInTheBranchPickerDoesNotCheckOut is why tier 1 is in
+// scope. A checkout is only reachable behind a modal, so a guard at the view
+// tier alone would leave the mutation this issue names as strictly worse than
+// dropping the input.
+//
+// [red] before the fix: the picker's Enter binding fires confirmBranch and the
+// terminal is handed to `git checkout`.
+func TestBatchSpellingEnterInTheBranchPickerDoesNotCheckOut(t *testing.T) {
+	opened := openPicker(t, pickerModel(domain.RepoState{
+		Head:     domain.HeadOnBranch,
+		Branch:   "main",
+		Branches: []string{"main", "feature"},
+	}))
+
+	after, cmd := opened.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("enter")})
+	got, ok := after.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, not a Model", after)
+	}
+
+	if cmd != nil {
+		t.Error("a batch spelling `enter` handed the terminal to a checkout through the picker")
+	}
+	if !got.modal.active {
+		t.Error("a batch closed the picker; inside a modal a batch is a no-op")
+	}
+	if got.modal.input.cursor != opened.modal.input.cursor {
+		t.Errorf("a batch moved the picker cursor: %d → %d",
+			opened.modal.input.cursor, got.modal.input.cursor)
+	}
+}
+
+// TestBatchSpellingCtrlCDoesNotQuit — the same collision, reachable from every
+// view. [red] before the fix: mkx exits.
+func TestBatchSpellingCtrlCDoesNotQuit(t *testing.T) {
+	for _, v := range []view{viewProjects, viewTargets} {
+		m := filterModel()
+		m.view = v
+
+		if _, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("ctrl+c")}); cmd != nil {
+			t.Errorf("view %v: a batch spelling `ctrl+c` issued a command; it quits", v)
+		}
+	}
+}
+
+// ---------------------------------------------- the three mutating lead runes
+
+// TestBatchBeginningWithBDoesNotOpenTheBranchPicker guards both halves at once.
+// The modal assertion is a regression guard against the naive per-rune fix,
+// which would make a pasted `branch` open the picker; the flash is what fails
+// today, because the batch is currently discarded in silence.
+func TestBatchBeginningWithBDoesNotOpenTheBranchPicker(t *testing.T) {
+	base := pickerModel(domain.RepoState{
+		Head:     domain.HeadOnBranch,
+		Branch:   "main",
+		Branches: []string{"main", "feature"},
+	})
+
+	for _, msg := range []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune("branch")},
+		{Type: tea.KeyRunes, Runes: []rune("branch"), Paste: true},
+	} {
+		after, cmd := base.Update(msg)
+		got, ok := after.(Model)
+		if !ok {
+			t.Fatalf("Update returned %T, not a Model", after)
+		}
+
+		if got.modal.active {
+			t.Errorf("%q (Paste=%v) opened the branch picker", string(msg.Runes), msg.Paste)
+		}
+		if cmd != nil {
+			t.Errorf("%q (Paste=%v) issued a command", string(msg.Runes), msg.Paste)
+		}
+		// [red] before the fix.
+		if got.flash == "" {
+			t.Errorf("%q (Paste=%v) was discarded in silence; an ignored batch is legible in a view",
+				string(msg.Runes), msg.Paste)
+		}
+	}
+}
+
+// TestBatchBeginningWithGDoesNotPull — `g` hands the terminal to git pull.
+func TestBatchBeginningWithGDoesNotPull(t *testing.T) {
+	m := filterModel()
+
+	after, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("gpull")})
+	got, ok := after.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, not a Model", after)
+	}
+
+	if cmd != nil {
+		t.Error("a batch beginning with `g` issued a command; it pulls")
+	}
+	// [red] before the fix.
+	if got.flash == "" {
+		t.Error("a batch beginning with `g` was discarded in silence")
+	}
+}
+
+// TestBatchBeginningWithCapitalRDoesNotOpenTheReadme — `R` is a full-screen
+// handover to the pager.
+func TestBatchBeginningWithCapitalRDoesNotOpenTheReadme(t *testing.T) {
+	m := filterModel()
+
+	after, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Readme")})
+	got, ok := after.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, not a Model", after)
+	}
+
+	if cmd != nil {
+		t.Error("a batch beginning with `R` issued a command; it opens the README")
+	}
+	// [red] before the fix.
+	if got.flash == "" {
+		t.Error("a batch beginning with `R` was discarded in silence")
+	}
+}
+
+// TestBatchCarryingEnterDoesNotRunATarget covers the runes only a bracketed
+// paste can carry. A raw replay never contains a control character —
+// detectOneMsg breaks the run on one — so a batch beginning with or ending in
+// Enter is expressible only as a paste.
+//
+// The third case is the one that proves the stripping rather than the guard: it
+// leads with `/`, so the sink does open, and the carriage return must not land
+// in the filter text.
+func TestBatchCarryingEnterDoesNotRunATarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		runes      string
+		wantFilter string
+	}{
+		{name: "a batch beginning with Enter", runes: "\rmake"},
+		{name: "a batch ending in Enter", runes: "make\r"},
+		{name: "a sink-opening batch ending in Enter", runes: "/make\r", wantFilter: "make"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ran string
+			m := filterModel()
+			m.app = app.New(fakeScanner{}, recordingRunner{ran: &ran}, fakeGitReader{})
+
+			after, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(tt.runes), Paste: true})
+			got, ok := after.(Model)
+			if !ok {
+				t.Fatalf("Update returned %T, not a Model", after)
+			}
+
+			if ran != "" {
+				t.Errorf("%q ran the target %q", tt.runes, ran)
+			}
+			if cmd != nil {
+				t.Errorf("%q issued a command", tt.runes)
+			}
+			// [red] before the fix, for the sink-opening case: no filter opened
+			// at all, so there was no text to strip the CR from.
+			if got.filter.text != tt.wantFilter {
+				t.Errorf("%q left filter text %q, want %q — control runes are stripped",
+					tt.runes, got.filter.text, tt.wantFilter)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------- the view with no sink
+
+// TestBatchInTheProjectViewIsIgnored proves the project view needs no code of
+// its own: it declares no `/`, so the same one rule ignores the batch and the
+// flash it derives from the registry names no key to press.
+//
+// [red] before the fix: no flash at all.
+func TestBatchInTheProjectViewIsIgnored(t *testing.T) {
+	m := filterModel()
+	m.view = viewProjects
+	m.projectCursor = 0
+
+	after, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/boot"), Paste: true})
+	got, ok := after.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, not a Model", after)
+	}
+
+	if cmd != nil {
+		t.Error("a batch in the project view issued a command")
+	}
+	if got.view != viewProjects {
+		t.Errorf("a batch changed the view to %v", got.view)
+	}
+	if got.projectCursor != m.projectCursor {
+		t.Errorf("a batch moved the project cursor: %d → %d", m.projectCursor, got.projectCursor)
+	}
+	if got.filter != (filterState{}) {
+		t.Errorf("a batch opened a filter in a view that has none: %+v", got.filter)
+	}
+	if got.flash == "" {
+		t.Fatal("a batch in the project view was discarded in silence")
+	}
+	if strings.Contains(got.flash, "/") {
+		t.Errorf("the project view's flash names `/` (%q); it binds no such key", got.flash)
+	}
+}
+
+// -------------------------------------------------- the registry invariant
+
+// TestOnlyTheFilterBindingOpensATextSink is the deny-by-default claim, pinned
+// across every keymap in the product, modal keymaps included.
+//
+// The modal keymaps are covered even though tier 1 never calls dispatchBatch
+// today, and deliberately so: the flag is what a future modal with a text field
+// would tick to become batch-reachable, so silently acquiring one is exactly
+// what this test exists to catch. A keymap is checked here before it is wired,
+// not after.
+//
+// It fails in both directions: a binding that stops declaring the flag fails
+// here, and so does a second binding that starts. Adding a text sink is
+// therefore a deliberate act with a test to edit, not something that arrives in
+// a future PR by accident.
+func TestOnlyTheFilterBindingOpensATextSink(t *testing.T) {
+	keymaps := map[string]keymap{
+		"projects":      projectKeymap(),
+		"targets":       targetKeymap(),
+		"help":          helpKeymap(),
+		"branch picker": branchPickerKeymap(),
+		"notice":        noticeKeymap(),
+	}
+
+	got := map[string][]string{}
+	for name, k := range keymaps {
+		for _, b := range k {
+			if b.opensTextSink {
+				got[name] = append(got[name], b.keys...)
+			}
+		}
+	}
+
+	want := map[string][]string{"targets": {"/"}}
+
+	for name, keys := range got {
+		if strings.Join(keys, ",") != strings.Join(want[name], ",") {
+			t.Errorf("%s keymap declares opensTextSink on %v, want %v", name, keys, want[name])
+		}
+	}
+	for name, keys := range want {
+		if _, ok := got[name]; !ok {
+			t.Errorf("%s keymap declares no opensTextSink binding, want %v", name, keys)
+		}
+	}
+
+	// The lookup the batch path actually uses, not just the field.
+	if b, ok := targetKeymap().textSink(); !ok || b.display != "/" {
+		t.Errorf("targetKeymap().textSink() = (%q, %v), want (\"/\", true)", b.display, ok)
+	}
+	if _, ok := projectKeymap().textSink(); ok {
+		t.Error("projectKeymap() reports a text sink; it binds no `/`")
+	}
+}
+
+// ------------------------------------------------------- flash legibility
+
+// TestAnIgnoredBatchFlashSurvivesARun is the legibility criterion in the state
+// where it was false: renderTargetList overwrote the flash from lastRun on
+// every render, so after any target run the batch flash was invisible.
+//
+// [red] before the fix.
+func TestAnIgnoredBatchFlashSurvivesARun(t *testing.T) {
+	m := filterModel()
+	m.lastRun = &runResult{ExitCode: 0}
+	m.flash = "Pasted input ignored — press / to filter"
+
+	rendered := ansi.Strip(m.renderTargetList())
+
+	if !strings.Contains(rendered, "Pasted input ignored") {
+		t.Error("the run receipt overwrote an explicit flash; an explicit flash is newer")
+	}
+	if strings.Contains(rendered, "✓") {
+		t.Error("the run receipt rendered alongside the flash; the flash slot holds one message")
+	}
+
+	// With no flash set, the receipt is still what fills the slot.
+	m.flash = ""
+	if !strings.Contains(ansi.Strip(m.renderTargetList()), "✓") {
+		t.Error("the run receipt stopped rendering when nothing else claimed the flash")
+	}
+}
+
+// ------------------------------------------------- the single-rune boundary
+
+// TestASinglePastedRuneDoesNotFireItsBinding is the case the length-alone
+// discriminator gets wrong. A typed `b` must still open the branch picker; a
+// pasted `b` must not.
+func TestASinglePastedRuneDoesNotFireItsBinding(t *testing.T) {
+	base := pickerModel(domain.RepoState{
+		Head:     domain.HeadOnBranch,
+		Branch:   "main",
+		Branches: []string{"main", "feature"},
+	})
+
+	typed, _ := base.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b")})
+	if got := typed.(Model); !got.modal.active {
+		t.Error("a typed `b` no longer opens the branch picker; the single-key path must be untouched")
+	}
+
+	pasted, cmd := base.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b"), Paste: true})
+	got, ok := pasted.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, not a Model", pasted)
+	}
+	if got.modal.active {
+		t.Error("a pasted `b` opened the branch picker; the discriminator is Paste || len>1, not length alone")
+	}
+	if cmd != nil {
+		t.Error("a pasted `b` issued a command")
+	}
+	if got.flash == "" {
+		t.Error("a pasted `b` was discarded in silence")
+	}
+}

--- a/internal/ui/tui/filter.go
+++ b/internal/ui/tui/filter.go
@@ -57,8 +57,26 @@ func (m Model) setFilterText(s string) Model {
 	return m
 }
 
+// appendFilterRunes appends rs to the filter text, dropping control runes.
+//
+// The stripping is here rather than at either call site because both of them
+// go through this one function: the tier-2 rune capture and the batch path in
+// batch.go. A bracketed paste carries every rune between the markers, so a
+// two-line clipboard entry brings \r and \n with it, and routed into the
+// filter bar they render as garbage that matches nothing.
+//
+// Space is 0x20 and survives — target descriptions are full of them, and the
+// capture accepts KeySpace precisely so a filter can contain one.
 func (m Model) appendFilterRunes(rs []rune) Model {
-	return m.setFilterText(m.filter.text + string(rs))
+	var b strings.Builder
+	b.WriteString(m.filter.text)
+	for _, r := range rs {
+		if r < 0x20 || r == 0x7f {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return m.setFilterText(b.String())
 }
 
 // backspaceFilter deletes the last rune, not the last byte: a multi-byte rune

--- a/internal/ui/tui/keymap.go
+++ b/internal/ui/tui/keymap.go
@@ -29,6 +29,17 @@ type binding struct {
 	// inBar marks a binding that appears in the hint bar. Help-only bindings
 	// (q/Quit in the target view) clear it.
 	inBar bool
+	// opensTextSink marks the one kind of binding a batch may fire: one whose
+	// whole effect is to switch the view into a mode that captures keystrokes
+	// as text. Today that is `/` and nothing else. The zero value is false, so
+	// a binding added later is inert to pasted input until someone
+	// deliberately says otherwise.
+	//
+	// It is not "safe to fire from a paste". `?` is safe to fire and opens no
+	// sink, so ticking it would make a pasted `?xyz` open help and drop `xyz`.
+	// Naming the field for the capability means it can only be ticked where
+	// the rest of the batch has somewhere to go. See batch.go.
+	opensTextSink bool
 	// handler runs the action. It receives the key that triggered it, so one
 	// handler can serve several keys.
 	handler func(Model, string) (Model, tea.Cmd)
@@ -92,13 +103,40 @@ func (k keymap) helpRows() []string {
 	return out
 }
 
-// dispatch returns the handler for key, or nil when no binding claims it. The
+// bindingFor returns the binding that claims key, or false when none does. The
 // first match wins, so an earlier binding shadows a later one.
-func (k keymap) dispatch(key string) func(Model, string) (Model, tea.Cmd) {
+//
+// dispatch wants only the handler; the batch path needs the whole binding, to
+// read opensTextSink before it fires anything. One lookup serves both.
+func (k keymap) bindingFor(key string) (binding, bool) {
 	for _, b := range k {
 		if slices.Contains(b.keys, key) {
-			return b.handler
+			return b, true
 		}
 	}
+	return binding{}, false
+}
+
+// dispatch returns the handler for key, or nil when no binding claims it.
+func (k keymap) dispatch(key string) func(Model, string) (Model, tea.Cmd) {
+	if b, ok := k.bindingFor(key); ok {
+		return b.handler
+	}
 	return nil
+}
+
+// textSink returns this keymap's text-sink binding, if it declares one.
+//
+// It answers "does this view have a sink at all, and which key opens it" —
+// which is what ignoredBatchFlash needs to name a key in the message a view
+// shows when it drops a batch. dispatchBatch does not use it: that path
+// already has a key in hand, so it looks the lead rune up with bindingFor and
+// reads opensTextSink off the binding it gets back.
+func (k keymap) textSink() (binding, bool) {
+	for _, b := range k {
+		if b.opensTextSink {
+			return b, true
+		}
+	}
+	return binding{}, false
 }

--- a/internal/ui/tui/keymap_views.go
+++ b/internal/ui/tui/keymap_views.go
@@ -106,6 +106,11 @@ func targetKeymap() keymap {
 			// Kept short: the help overlay's inner width is ~44 columns at
 			// 80×24, and a row that truncates fails the suite.
 			help: "Filter by name or description", inBar: true,
+			// The only opensTextSink binding in the product. Its whole effect
+			// is to open filter mode, so the rest of a pasted batch has
+			// somewhere to land. Nothing else here qualifies, and no modal
+			// keymap declares one — pinned by TestOnlyTheFilterBindingOpensATextSink.
+			opensTextSink: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				return m.activateFilter(), nil
 			}},

--- a/internal/ui/tui/model.go
+++ b/internal/ui/tui/model.go
@@ -219,10 +219,27 @@ func (m Model) dispatch(msg tea.Msg) (Model, tea.Cmd) {
 // Tier 2 sits after tier 1's unconditional return, so with a modal up the
 // filter never sees a key. When filter mode is inactive it is a no-op and the
 // path is what it was before filtering existed.
+//
+// Tiers 1 and 3 each branch on batch-ness before consulting their keymap: a
+// KeyMsg carrying runes that arrived in a single terminal read never reaches
+// keymap.dispatch, in either tier. That is the safety property, and the two
+// guards below are where it lives. Tier 2 is untouched — filter mode already
+// handled batches correctly, because it captures runes rather than matching a
+// key string. See batch.go for the rule and why it is shaped this way.
 func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	key := msg.String()
 
 	if m.modal.active {
+		// batch-guard: tier 1. A raw multiplexer replay spelling `enter`
+		// arrives as KeyRunes("enter"), whose String() is "enter" — so without
+		// this the branch picker's Enter binding fires and replayed text
+		// performs a checkout. Inside a modal a batch is a silent no-op rather
+		// than a flash: the modal already contracts every unbound key to
+		// silence, and a flash rendered into the dimmed hint bar behind an
+		// overlay would be the odd one out.
+		if isBatch(msg) {
+			return m, nil
+		}
 		if h := m.modal.keys.dispatch(key); h != nil {
 			return h(m, key)
 		}
@@ -256,6 +273,15 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		case msg.Type == tea.KeyBackspace:
 			return m.backspaceFilter(), nil
 		}
+	}
+
+	// batch-guard: tier 3. A batch never reaches the view's keymap, so no
+	// whole-string match is ever performed on one — which is what makes `b`,
+	// `g`, `R`, `q`, `enter`, `esc` and `ctrl+c` unreachable from pasted or
+	// replayed input structurally, rather than by an exclusion list a future
+	// binding could fall off.
+	if isBatch(msg) {
+		return m.dispatchBatch(m.viewKeymap(), msg)
 	}
 
 	if h := m.viewKeymap().dispatch(key); h != nil {
@@ -584,7 +610,15 @@ func (m Model) renderTargetList() string {
 
 	s += styles.Border.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
 
-	if m.lastRun != nil {
+	// The run receipt fills the flash slot only when nothing else has claimed
+	// it. An explicit flash is newer than the receipt, and unconditionally
+	// overwriting it made the ignored-batch message invisible in the common
+	// state of "having just run something" — which would make the legibility
+	// criterion false exactly where a user is most likely to paste. It repairs
+	// a pre-existing instance of the same clobber too: gitPullFinishedMsg's
+	// "Pulled & refreshed" was being replaced by the receipt on the next
+	// render. Widening the flash guarantee is deliberate, not incidental.
+	if m.flash == "" && m.lastRun != nil {
 		status := "✓"
 		if m.lastRun.ExitCode != 0 {
 			status = fmt.Sprintf("✗ exit %d", m.lastRun.ExitCode)

--- a/scripts/verify-batch-guard.sh
+++ b/scripts/verify-batch-guard.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Proves the batched-input guards actually fail.
+#
+# TAE-61's whole deliverable is behaviour that must not happen: no batch fires a
+# checkout, a pull or a target run. A green suite does not demonstrate that —
+# only that nothing tripped. So each case below removes one of handleKey's two
+# batch guards in a throwaway copy of the repository and asserts the batch tests
+# go red, by name. Your working tree is never touched.
+#
+# The two guards are sabotaged independently, and that is the point. A single
+# sabotage point would leave one of them unproven: tier 3 keeps a batch away
+# from the view's keymap, tier 1 keeps it away from an open modal's, and only
+# tier 1 stands between a replayed `enter` and a git checkout. Removing them
+# together would let either one carry the other's evidence.
+#
+# Run via: make verify-batch-guard
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PKG="./internal/ui/tui/"
+MODEL="internal/ui/tui/model.go"
+
+# The sentinel comments in handleKey. Each opens the guard it names; the
+# sabotage below deletes from the sentinel through the guard's closing brace.
+TIER1_SENTINEL="// batch-guard: tier 1."
+TIER3_SENTINEL="// batch-guard: tier 3."
+
+failures=0
+
+# fresh_copy <name> — a pristine copy of the working tree, minus git and build output.
+fresh_copy() {
+	local dest="$WORK/$1"
+	mkdir -p "$dest"
+	tar -C "$REPO_ROOT" --exclude=.git --exclude=dist --exclude=mkx -cf - . | tar -C "$dest" -xf -
+	echo "$dest"
+}
+
+# strip_guard <label> <dir> <sentinel> — delete the sentinel comment block and
+# the guard that follows it, up to and including its closing brace.
+#
+# The copy must actually change. A sentinel that no longer matches — because the
+# comment was reworded, or handleKey was restructured — would otherwise leave the
+# guard in place, the tests would pass, and this script would report success
+# while checking nothing. That is the exact false confidence it exists to rule
+# out, so a no-op sabotage is a failure here, not a silent skip.
+strip_guard() {
+	local label="$1" dir="$2" sentinel="$3"
+	local file="$dir/$MODEL"
+
+	awk -v s="$sentinel" '
+		index($0, s) { skip = 1; next }
+		skip && /^[[:space:]]*}[[:space:]]*$/ { skip = 0; next }
+		skip { next }
+		{ print }
+	' "$file" > "$file.tmp" || { printf 'FAIL  %s\n      the sabotage step itself errored\n' "$label"; failures=$((failures + 1)); return 1; }
+
+	if cmp -s "$file" "$file.tmp"; then
+		printf 'FAIL  %s\n      the sentinel %s matched nothing in %s — this script has stopped checking\n' \
+			"$label" "$sentinel" "$MODEL"
+		failures=$((failures + 1))
+		rm -f "$file.tmp"
+		return 1
+	fi
+
+	mv "$file.tmp" "$file"
+}
+
+# expect_red <label> <dir> <test-name>... — the suite in dir must fail, and each
+# named test must be among the failures.
+#
+# A nonzero exit is not enough. A copy broken by the sabotage, a module-cache
+# hiccup or a compile error also exits nonzero, and accepting that would let this
+# script report success while no guard ever fired. So each case names the tests
+# whose failure is the evidence, and only those count as a pass.
+expect_red() {
+	local label="$1" dir="$2"
+	shift 2
+	local out missing=0
+
+	if out="$(cd "$dir" && go test -count=1 "$PKG" 2>&1)"; then
+		printf 'FAIL  %s\n      suite stayed GREEN — the guard did not trip\n' "$label"
+		failures=$((failures + 1))
+		return
+	fi
+
+	for name in "$@"; do
+		if ! printf '%s' "$out" | grep -qF -- "--- FAIL: $name"; then
+			printf 'FAIL  %s\n      %s did not go red; the suite failed for some other reason\n' "$label" "$name"
+			missing=1
+		fi
+	done
+
+	if [ "$missing" -ne 0 ]; then
+		printf '%s\n' "$out" | sed 's/^/        /'
+		failures=$((failures + 1))
+		return
+	fi
+
+	printf 'PASS  %s\n' "$label"
+	for name in "$@"; do
+		printf '      red: %s\n' "$name"
+		printf '%s' "$out" | grep -A2 -F -- "--- FAIL: $name" | grep -E '^\s+batch_test\.go' | head -2 | sed 's/^[[:space:]]*/           /'
+	done
+}
+
+echo "Sabotaging throwaway copies under $WORK"
+echo
+
+# --- 1. Tier 3 removed: a batch reaches the view's keymap -------------------
+#
+# The defect this issue was filed for, plus the view-level half of the collision
+# found during planning: a replayed `enter` runs the selected Make target.
+d="$(fresh_copy strip-tier-3)"
+if strip_guard "tier 3 sabotage" "$d" "$TIER3_SENTINEL"; then
+	expect_red "tier 3 removed — a batch reaches the view keymap" "$d" \
+		TestPastedFilterStringOpensFilterModeAndTypesTheRest \
+		TestReplayedFilterStringDoesTheSame \
+		TestBatchSpellingEnterDoesNotRunATarget \
+		TestBatchSpellingCtrlCDoesNotQuit \
+		TestBatchBeginningWithBDoesNotOpenTheBranchPicker \
+		TestBatchBeginningWithGDoesNotPull \
+		TestBatchBeginningWithCapitalRDoesNotOpenTheReadme \
+		TestBatchInTheProjectViewIsIgnored \
+		TestASinglePastedRuneDoesNotFireItsBinding
+fi
+echo
+
+# --- 2. Tier 1 removed: a batch reaches an open modal's keymap --------------
+#
+# The mutation only tier 1 stands between: with the branch picker open, a raw
+# replay spelling `enter` reaches confirmBranch and hands the terminal to
+# `git checkout`. Nothing at tier 3 can see this, which is why it is sabotaged
+# on its own.
+d="$(fresh_copy strip-tier-1)"
+if strip_guard "tier 1 sabotage" "$d" "$TIER1_SENTINEL"; then
+	expect_red "tier 1 removed — a batch reaches the modal keymap" "$d" \
+		TestBatchSpellingEnterInTheBranchPickerDoesNotCheckOut
+fi
+echo
+
+if [ "$failures" -ne 0 ]; then
+	echo "$failures guard(s) failed to trip — batched input is not guarded."
+	exit 1
+fi
+
+echo "Both batch guards tripped as required."


### PR DESCRIPTION
Runes arriving in a single terminal read were dropped at view dispatch. `handleKey` matches `msg.String()` whole, and a batch's string matches no binding, so pasting `/boot` did nothing.

Planning found the defect is **worse than silent discard**, and that finding is what makes this PR bigger than the issue title suggests. Bubble Tea brackets a *pasted* batch — `[/boot]` — so a real paste can never activate a shortcut. A multiplexer replaying buffered bytes produces an **unbracketed** batch whose `String()` is the literal text, and five words collide with MkX's bindings: `enter`, `esc`, `up`, `down`, `ctrl+c`. On `main`, a replayed `enter` runs the selected Make target, and with the branch picker open it reaches `confirmBranch` and **checks out a branch**. That is replayed input firing a mutation — the outcome the issue names as strictly worse than dropping the input — and it was live before any fix was written.

## The rule

> A batch may only ever open a text sink. Its **first rune only** is looked up in the active keymap, and the handler runs **only if that binding declares `opensTextSink`**. The remaining runes go to the sink as literal text. A batch whose first rune opens no sink fires nothing and sets a flash saying so. A batch never returns a `tea.Cmd`. Inside a modal it is a no-op.

The discriminator is `msg.Paste || len(msg.Runes) > 1` — **not length alone**, or a pasted single `b` still opens the branch picker.

Safe by three independent layers, not one:

1. **A batch never reaches `keymap.dispatch`.** `b`, `g`, `R`, `q`, `enter`, `esc`, `ctrl+c` are unreachable from a batch *structurally*, not by an exclusion list a future binding could fall off. This is also what closes the five-word collision.
2. **Deny-by-default on the flag.** `opensTextSink`'s zero value is false, so a binding added later is inert to pasted input until someone opts in. Today `/` is the only one, pinned in **both** directions by `TestOnlyTheFilterBindingOpensATextSink` across every view **and modal** keymap.
3. **`dispatchBatch` discards any `tea.Cmd` a handler returns.** Even a binding wrongly marked as a sink cannot hand the terminal to a process. The cost — a future sink whose handler legitimately needs to return a command would have it dropped — is written down at the discard site, so whoever adds the second sink revisits it on purpose.

## Acceptance criteria

| AC | How | Where |
|---|---|---|
| Pasting `/boot` leaves filter mode active with `boot` typed | `/` gains `opensTextSink: true`; `activateFilter` runs; `boot` is appended | `TestPastedFilterStringOpensFilterModeAndTypesTheRest`, `TestReplayedFilterStringDoesTheSame` |
| A batch matching nothing is not silently discarded **in a view**; inside a modal it is silently ignored | in a view, a flash derived from the registry; in a modal, a no-op | `TestBatchBeginningWith{B,G,CapitalR}…`, `TestBatchInTheProjectViewIsIgnored`, `TestBatchSpellingEnterInTheBranchPickerDoesNotCheckOut` |
| No batch fires a checkout, a pull, or a target run | the three layers above, at tier 1 **and** tier 3 | `TestBatchSpellingEnterDoesNotRunATarget`, `…InTheBranchPickerDoesNotCheckOut`, `TestBatchSpellingCtrlCDoesNotQuit` |
| Tests drive `Update` with real multi-rune `KeyMsg` values | inline `tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("…"), Paste: …}` literals; no helper is added | all of `batch_test.go` |

The flash is **derived from the registry**, so no view carries batch-specific code: the target view shows `Pasted input ignored — press / to filter`, and the project view, which declares no `/`, shows `Pasted input ignored`.

## Also in scope, because the legibility criterion rests on them

- **`renderTargetList` overwrote the flash from `lastRun` on every render**, so after any target run an ignored-batch flash was invisible — the legibility criterion would have been false in a common state. It now fills the slot only when nothing else has claimed it. This also repairs a pre-existing instance of the same clobber, where `gitPullFinishedMsg`'s "Pulled & refreshed" was being replaced by the run receipt. **A deliberate widening of the flash guarantee, flagged rather than slipped in.**
- **`appendFilterRunes` strips control runes.** A bracketed paste carries `\r` and `\n`; routed into filter text they render as garbage. The stripping is inside the one function both the tier-2 capture and the batch path already call. Space is `0x20` and survives.

## One addition beyond the approved plan

`scripts/verify-batch-guard.sh` is wired into CI's existing `guards` job. The plan did not specify this; an in-session review caught that without it, the script would run only when someone remembered — which defeats the plan's own stated reason for putting it in the repo rather than pasting it into a merged PR. `ci.yml`'s `guards` job already carries that exact rationale in a comment for the oracle guards, so this follows the repo's own precedent rather than inventing one. The script uses `awk`, not GNU `sed`, so the job's ubuntu-only constraint is not a problem for it.

## Known and not closed

A raw replay of `make\n` arrives as `KeyRunes("make")` **and then a separate `KeyEnter`**. The batch becomes filter text; the bare Enter is indistinguishable from a real keypress and still runs the selected target. Bracketed paste — the default, and what Zellij forwards — prevents it, because there `\r` stays a rune inside the batch. Closing the residual case needs a timing heuristic that would misfire on a fast typist and cannot be tested without injecting a clock. Recorded in a code comment in `batch.go`, not engineered around.

## Observed, not fixed: the hint bar wraps when a flash is set

In the target view, **any** flash pushes the hint bar to a second line — the bar is already exactly 78 of 78 columns. The flash lands legibly on its own row. In the project view it wraps mid-phrase (`Pasted input` / `ignored`).

This is **pre-existing and unchanged by this PR** — verified by rendering `Pulled & refreshed` against `main`, which wraps identically. It is the fixed-width bar TAE-60 exists to fix. Flagged so the two-line bar in the manual steps below does not read as a regression.

---

# Verification handoff

Run top to bottom. Every target existed before this PR except `verify-batch-guard`, which it adds.

| # | Command | Purpose | Expected |
|---|---|---|---|
| 1 | `make build` | It compiles | `mkx` produced, no other output |
| 2 | `make verify-tui` | The new batch tests plus the whole existing TUI suite | all PASS — 322 test cases, `ok internal/ui/tui` |
| 3 | `make verify-batch-guard` | **Proves the new tests fail when the fix is removed** | two `PASS` blocks, each listing the tests that went red in a sabotaged copy, then `Both batch guards tripped as required.` |
| 4 | `make verify` | Discovery untouched — no golden movement | `TestCharacterization` PASS with **no rebaseline**; this change is `ui/tui` only |
| 5 | `make verify-parser` | Make parser untouched | PASS |
| 6 | `make verify-gitx` | Git adapters untouched | PASS |
| 7 | `make test` | Whole suite | PASS, every package `ok` |
| 8 | `make tidy-check` | No module drift | clean, no diff |

Steps 1–8 were run by me from a **clean clone of this branch**, not from a working tree — local green is not committed green. Step 3 is the one that carries the weight. The deliverable here is behaviour that must *not* happen, and a green suite only shows nothing tripped. `verify-batch-guard` removes each of `handleKey`'s two guards **independently** in a throwaway copy — tier 3, then tier 1 — and fails unless the batch tests go red **by name**. Two sabotage points, not one: tier 1 is the only thing between a replayed `enter` and a `git checkout`, and a combined sabotage would let tier 3 carry its evidence. If a sentinel comment ever stops matching, the script reports failure rather than silently passing.

## Manual, in Zellij — the trigger is paste, so no Go test exercises the real path

**These matter more than usual here.** Every automated test above injects a `KeyMsg` directly; none of them proves the terminal actually delivers a batch the way this fix assumes.

Use the throwaway git workspace for the branch-picker step, so a failure cannot check out a branch in a repository you care about:

```
make demo-git          # prints a temp workspace path and leaves it behind
cd <that path> && /home/gaetan/Projects/Taelron/MKX/mkx
```

Steps 9–13 can use `make run` (the `testdata/fixtures` workspace: `alpha` has `build`, `test`, `clean`, `install`).

| # | Action | Expected |
|---|---|---|
| 9 | `make run`, `Enter` into `alpha`, then **paste** `/bui` | filter mode active, bar reads `Filter: bui`, list narrowed to `build` |
| 10 | Esc, then paste `/boot` | bar reads `Filter: boot` and the list shows `No targets match. Press Esc to clear the filter.` — no fixture target contains "boot", so an empty result is the correct pass. The criterion is that filter mode opened with `boot` typed |
| 11 | Esc, then paste `boot` (no leading `/`) | list unchanged, hint bar reads `Pasted input ignored — press / to filter` (on its own second line) |
| 12 | Paste `branch`, then `gpull`, then `Readme` | no branch picker, no pull, no README; a flash each time |
| 13 | Paste the literal word `enter` | **no target runs** — this is the collision found during planning |
| 14 | Run a target with `Enter`, return, then paste `boot` | the flash is visible and is **not** replaced by the `✓ 0s` receipt. Press any key: the receipt comes back |
| 15 | **In the `make demo-git` workspace:** enter `clean`, press `b` to open the branch picker, then paste the literal word `enter` | **no checkout.** The picker stays open, the cursor does not move, nothing happens. This is the one that proves tier 1 — on `main` it checks out the selected branch |
| 16 | Paste a two-line string ending in a newline, leading with `/` | the newline is not in the filter text and no target runs |
| 17 | Type `/build` normally, one key at a time; then press `b`, `g`, `Enter` normally | unchanged from today — the single-key path is not touched |

If step 15 checks anything out, stop and report it rather than working around it.

---

The architect plan for this issue is on the Linear issue as a comment: https://linear.app/taelron/issue/TAE-61/batched-key-input-is-silently-dropped-at-view-dispatch

Closes TAE-61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
