### PR TITLE
Bound a captured git read whose descendant holds stdout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,9 @@ jobs:
       # removes each of handleKey's two guards in a throwaway copy and fails
       # unless the batch tests go red by name.
       - run: make verify-batch-guard
+      # TAE-62's read bound, the same class of claim: the deliverable is a git
+      # read that does not hang, which a green suite cannot demonstrate. This
+      # removes cmd.WaitDelay in a throwaway copy and fails unless the
+      # descendant-holds-the-pipe case goes red while the case that does not
+      # need the bound stays green.
+      - run: make verify-waitdelay-guard

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY   := mkx
 FIXTURES := testdata/fixtures
 
-.PHONY: build test verify verify-parser verify-gitx verify-tui verify-guards verify-batch-guard rebaseline-golden tidy-check run demo-git
+.PHONY: build test verify verify-parser verify-gitx verify-tui verify-guards verify-batch-guard verify-waitdelay-guard rebaseline-golden tidy-check run demo-git demo-hung-git
 
 build: ## Compile the mkx binary
 	go build -o $(BINARY) ./cmd/mkx
@@ -17,9 +17,11 @@ verify: ## Check discovery behaviour against the committed golden
 verify-parser: ## Run the pure parser table tests
 	go test -v -count=1 ./internal/adapter/makex/
 
-verify-gitx: ## Run the pure git classifier and parser table tests
-	# No git process is spawned by these: they drive the classifiers from
-	# captured strings, so they pass identically on a box with no git.
+verify-gitx: ## Run the git classifier tests and the bounded-read test
+	# The classifier and parser tests spawn nothing: they drive the classifiers
+	# from captured strings, so they pass identically on a box with no git. The
+	# bounded-read test (unix only) is the one exception, and it does not
+	# invoke the real binary either — it puts a shell shim named `git` on PATH.
 	go test -v -count=1 ./internal/adapter/gitx/
 
 verify-tui: ## Run the TUI keymap, modal and overlay tests by name
@@ -30,6 +32,9 @@ verify-guards: ## Prove the golden guards fail — sabotages a throwaway copy, n
 
 verify-batch-guard: ## Prove the batched-input tests fail when either guard is removed
 	./scripts/verify-batch-guard.sh
+
+verify-waitdelay-guard: ## Prove the bounded-read test fails when the read bound is removed
+	./scripts/verify-waitdelay-guard.sh
 
 rebaseline-golden: ## Re-anchor the golden to current behaviour — reviewed behaviour changes only
 	go test -count=1 -v -run '^TestCharacterization$$' ./internal/app/ -rebaseline
@@ -43,3 +48,6 @@ run: build ## Launch the TUI against testdata/fixtures
 
 demo-git: build ## Build a throwaway workspace covering every git display state
 	./scripts/demo-git.sh
+
+demo-hung-git: build ## Build a throwaway workspace whose git never answers, to watch a read degrade
+	./scripts/demo-hung-git.sh

--- a/internal/adapter/gitx/gitx.go
+++ b/internal/adapter/gitx/gitx.go
@@ -137,6 +137,22 @@ func run(ctx context.Context, dir string, args ...string) result {
 
 	cmd := exec.CommandContext(ctx, "git", argv...)
 	cmd.Stdin = nil
+
+	// waitdelay-guard: the deadline alone does not bound the read.
+	//
+	// CommandContext kills git when ctx expires, but Wait then blocks on the
+	// captured stdout pipe below for as long as any descendant of git holds
+	// the write end open — and a killed parent does not close its children's
+	// copies. Without this the read never returns, past the deadline that
+	// exists to prevent exactly that (ADR-M003, TAE-62).
+	//
+	// It bounds two shapes, not one. When ctx expires the timer starts at
+	// cancellation, so the delay and the caller's deadline compose additively.
+	// When git instead exits cleanly and a descendant outlives it — the
+	// fsmonitor case — the timer starts at exit and ctx never fires at all,
+	// which is why the failure below is classified from err rather than from
+	// ctx.Err(). Both numbers and the total are at app.GitWaitDelay.
+	cmd.WaitDelay = app.GitWaitDelay
 	cmd.Env = append(os.Environ(),
 		"LC_ALL=C",
 		"LANG=C",
@@ -164,8 +180,18 @@ func run(ctx context.Context, dir string, args ...string) result {
 		if errors.As(err, &exitErr) {
 			res.exitCode = exitErr.ExitCode()
 		} else {
-			// git could not be started at all — not on PATH, or not
-			// executable. Not a repository state; a failed read.
+			// Either git could not be started at all — not on PATH, or not
+			// executable — or Wait gave up on the pipes after WaitDelay
+			// elapsed (exec.ErrWaitDelay), which is reported here rather than
+			// as an ExitError. Neither is a repository state; both are failed
+			// reads.
+			//
+			// The WaitDelay case is a failure deliberately, not by omission:
+			// output that arrived through a pipe closed under it may be
+			// truncated, and ADR-M003 forbids a read that cannot be trusted
+			// from degrading to anything other than unknown. Do not "tidy"
+			// this into a success path on the grounds that the exit code
+			// looked fine.
 			res.exitCode = -1
 			if res.stderr == "" {
 				res.stderr = err.Error()

--- a/internal/adapter/gitx/run_bounded_test.go
+++ b/internal/adapter/gitx/run_bounded_test.go
@@ -1,0 +1,160 @@
+//go:build unix
+
+package gitx
+
+// The one test in this package that spawns processes.
+//
+// TAE-62: the read deadline kills git, but Wait then blocks on the captured
+// stdout pipe for as long as a descendant holds it open. The fix is
+// cmd.WaitDelay; this is the proof that it is doing something, and the shape
+// below is the one the M2 exit verification isolated the defect down to.
+//
+// The whole reproduction is one word. `exec sleep` replaces the shell, so the
+// process the deadline kills is the only one holding the pipe and the read was
+// already bounded without the fix. A bare `sleep` leaves a child behind: the
+// shell is killed, the sleep is not, and it holds the write end. Both shapes
+// run here, because a test that reddens for both is failing for some other
+// reason and proves nothing about the mechanism — scripts/verify-waitdelay-guard.sh
+// asserts exactly that asymmetry.
+//
+// unix-only: the reproduction needs /bin/sh and orphan semantics. The fix
+// itself is platform-independent — WaitDelay is not a unix concept — so
+// nothing about the behaviour is untested on Windows except this proof of it.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/app"
+)
+
+const (
+	// A short stand-in for app's two seconds. This test is about the shape of
+	// the bound, not about its production value, and a process-spawning test
+	// should not cost two seconds per case to make its point.
+	testDeadline = 300 * time.Millisecond
+
+	// Room for a loaded CI box on top of deadline + WaitDelay. It can be
+	// generous: what it has to distinguish itself from is the shim's
+	// 60-second sleep, so the margin is a factor of twelve rather than a few
+	// milliseconds. A false failure needs a machine six times slower than the
+	// budget already allows; a false pass would need a 60-second sleep to
+	// finish early, which is not a thing that happens.
+	slack = 4 * time.Second
+)
+
+func TestRunBoundsAKilledProcessWhoseDescendantHoldsStdout(t *testing.T) {
+	cases := []struct {
+		name string
+		shim string
+	}{
+		{
+			// Nothing survives the kill: the deadline alone bounds this, with
+			// or without the fix. Here to prove the other case is not simply
+			// red for an unrelated reason.
+			name: "exec-sleep",
+			shim: "#!/bin/sh\nexec sleep 60\n",
+		},
+		{
+			// The defect. sh is killed at the deadline; the backgrounded sleep
+			// is not, and it still holds the stdout pipe MkX is capturing
+			// into. The pid is recorded so the test can clean up after itself
+			// instead of leaving a minute-long orphan behind.
+			name: "bare-sleep",
+			shim: "#!/bin/sh\nsleep 60 &\necho $! > \"$MKX_TEST_PIDFILE\"\nwait\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bin := t.TempDir()
+			pidfile := filepath.Join(t.TempDir(), "descendant.pid")
+
+			if err := os.WriteFile(filepath.Join(bin, "git"), []byte(tc.shim), 0o755); err != nil {
+				t.Fatalf("write shim: %v", err)
+			}
+
+			t.Setenv("MKX_TEST_PIDFILE", pidfile)
+			// Prepended, never replaced: LookPath takes the first match so the
+			// shim still wins, and the shim's own `sleep` has to resolve.
+			t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Cleanup(func() { killRecordedDescendant(t, pidfile) })
+
+			ctx, cancel := context.WithTimeout(context.Background(), testDeadline)
+			defer cancel()
+
+			budget := testDeadline + app.GitWaitDelay + slack
+
+			// run goes in a goroutine so an unbounded read fails the test in
+			// `budget` rather than hanging until go test's own timeout. That
+			// matters for the guard script, which runs this sabotaged and
+			// needs the red verdict in seconds.
+			done := make(chan result, 1)
+			start := time.Now()
+			go func() { done <- run(ctx, t.TempDir(), "rev-parse", "--abbrev-ref", "HEAD") }()
+
+			select {
+			case res := <-done:
+				elapsed := time.Since(start)
+
+				// The two anti-vacuity assertions. A test asserting that
+				// something does NOT hang passes perfectly when the
+				// reproduction silently fails to reproduce — a shim that is
+				// not found, or a `sleep` that does not resolve, returns in a
+				// millisecond and looks exactly like a fix working. Both
+				// checks below fail in that case: an unstarted command leaves
+				// ctxErr nil, and it cannot have taken the deadline to do it.
+				if !errors.Is(res.ctxErr, context.DeadlineExceeded) {
+					t.Fatalf("ctxErr = %v (exit %d, stderr %q), want context.DeadlineExceeded — "+
+						"the shim did not hang, so this run proves nothing about the bound",
+						res.ctxErr, res.exitCode, strings.TrimSpace(res.stderr))
+				}
+				if elapsed < testDeadline {
+					t.Fatalf("run returned after %v, before its own %v deadline — "+
+						"the read never reached the deadline it is supposed to be bounded past",
+						elapsed, testDeadline)
+				}
+
+				t.Logf("bounded: run returned after %v (%v deadline + %v WaitDelay)",
+					elapsed.Round(time.Millisecond), testDeadline, app.GitWaitDelay)
+
+			case <-time.After(budget):
+				t.Fatalf("run did not return within %v (%v deadline + %v WaitDelay + %v slack) — "+
+					"the read is unbounded: a descendant is holding the captured stdout pipe "+
+					"open past the deadline",
+					budget, testDeadline, app.GitWaitDelay, slack)
+			}
+		})
+	}
+}
+
+// killRecordedDescendant kills the orphan the bare-sleep shim left behind, if
+// there is one. Absence is not a failure: the exec-sleep case records no pid
+// because it deliberately leaves nothing running.
+//
+// It also unblocks a run() that is still hanging — in the sabotaged build the
+// goroutine above is stuck on the pipe this process is holding.
+func killRecordedDescendant(t *testing.T, pidfile string) {
+	t.Helper()
+
+	raw, err := os.ReadFile(pidfile)
+	if err != nil {
+		return
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil {
+		t.Logf("descendant pid %q is not a number; leaving it to exit on its own", raw)
+		return
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return
+	}
+	_ = proc.Kill()
+}

--- a/internal/app/usecases.go
+++ b/internal/app/usecases.go
@@ -13,21 +13,65 @@ import (
 	"github.com/Gaetan-Jaminon/mkx/internal/domain"
 )
 
-// gitReadTimeout bounds one whole RepoState read — all three git commands,
-// not one deadline each. ADR-M003 requires captured reads to be bounded; the
-// AC asks for "a context with a timeout", singular. When the budget runs out
-// mid-sequence the next command fails immediately rather than spawning.
+// The git read budget, both halves.
 //
-// A warm local read of these commands is single-digit milliseconds. A cold or
-// very large working tree can push `status --porcelain` into the hundreds,
-// occasionally past a second on networked storage. The index-lock hazard is
-// eliminated by --no-optional-locks in the adapter rather than budgeted for
-// here. Two seconds is roughly two orders of magnitude above a warm read and
-// still short enough that a genuinely stuck read resolves while the user is
-// looking at the view.
+// They are declared together because neither number is the bound on its own.
+// The worst case a user can observe is their sum: 2.5 seconds from issuing a
+// read to the header degrading to unknown. Written in two places, the next
+// reader finds one of them and gets the total wrong — which is how TAE-62
+// stayed invisible while the deadline looked correct in isolation.
 //
-// Unexported and unconfigurable, per ADR-M004.
-const gitReadTimeout = 2 * time.Second
+// At most one wait delay is ever charged to a read, so the total is 2s + 500ms
+// and not 2s + three of them: every path that can incur the delay is a failure
+// path, and RepoState returns on the first failure rather than issuing the next
+// command.
+//
+// Both are compile-time constants. No flag, no environment variable, no file,
+// per ADR-M004.
+const (
+	// gitReadTimeout bounds one whole RepoState read — all three git commands,
+	// not one deadline each. ADR-M003 requires captured reads to be bounded; the
+	// AC asks for "a context with a timeout", singular. When the budget runs out
+	// mid-sequence the next command fails immediately rather than spawning.
+	//
+	// A warm local read of these commands is single-digit milliseconds. A cold or
+	// very large working tree can push `status --porcelain` into the hundreds,
+	// occasionally past a second on networked storage. The index-lock hazard is
+	// eliminated by --no-optional-locks in the adapter rather than budgeted for
+	// here. Two seconds is roughly two orders of magnitude above a warm read and
+	// still short enough that a genuinely stuck read resolves while the user is
+	// looking at the view.
+	//
+	// Unexported: nothing outside this package needs the number.
+	gitReadTimeout = 2 * time.Second
+
+	// GitWaitDelay bounds how long cmd.Wait may block once the git process
+	// itself is gone (TAE-62).
+	//
+	// Git ending does not end the read. The adapter captures output into a
+	// strings.Builder, so os/exec runs it through a pipe and a copying
+	// goroutine, and that goroutine cannot return while any descendant of git
+	// still holds the write end — a core.fsmonitor daemon, say. Without a
+	// delay Wait blocks on that pipe indefinitely, past the deadline whose
+	// entire purpose is to prevent an unbounded read.
+	//
+	// It covers two shapes. Killed at the deadline with a descendant left
+	// behind, where this is charged on top of the 2s above; and exited
+	// cleanly with a descendant left behind, where the deadline never fires
+	// and this is the only bound there is.
+	//
+	// Half a second, because in this failure mode waiting longer never rescues
+	// the read: the descendant holds the pipe for as long as it lives, so extra
+	// time only postpones the unknown state the caller is already owed. The
+	// floor is the time a healthy process that has exited needs to drain a
+	// local pipe — microseconds — so 500ms cannot turn a good read into a
+	// spurious unknown, and it absorbs SIGKILL delivery to a process that is
+	// momentarily unschedulable.
+	//
+	// Exported because the gitx adapter sets it on the command: the mechanism
+	// belongs to os/exec, the budget belongs to this layer.
+	GitWaitDelay = 500 * time.Millisecond
+)
 
 // App composes the ports into MkX's use cases. Constructed in cmd/mkx/main.go.
 type App struct {

--- a/scripts/demo-hung-git.sh
+++ b/scripts/demo-hung-git.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Builds a throwaway workspace whose `git` never answers, so the read bound can
+# be watched degrading on screen.
+#
+# This is the half of TAE-62 the unit test cannot show. The test proves the
+# mechanism — run() returns within deadline + WaitDelay — but ADR-M003's promise
+# is about what the user gets: a header that degrades to unknown, bounded, with
+# the TUI interactive the whole time. That is three claims about a screen, and
+# they are verified by looking at one.
+#
+# The shim is the shape TAE-62 was isolated to. A bare `sleep` rather than
+# `exec sleep` is the entire point: the shell is killed at the deadline and the
+# backgrounded sleep is not, so it goes on holding the stdout pipe MkX is
+# capturing into. With `exec` there is no descendant and the deadline alone was
+# always enough — that case never reproduced the defect.
+#
+# Nothing here touches your working tree, and no real git repository is
+# involved: the shim intercepts every git invocation, so there is nothing for a
+# repository to tell MkX. The workspace is left behind deliberately — the point
+# is to run mkx in it — and is yours to delete.
+#
+# Run via: make demo-hung-git
+
+set -euo pipefail
+
+WORK="$(mktemp -d -t mkx-hung-git-XXXXXX)"
+MKX="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/mkx"
+
+mkdir -p "$WORK/bin"
+
+# The shim, named `git` and first on PATH. It answers nothing, ever: whatever
+# MkX asks, it backgrounds a sleep that inherits stdout and then waits to be
+# killed. `wait` rather than a second sleep so the shell has no work of its own
+# to be interrupted in.
+#
+# 300 seconds is long enough that the descendant outlives any plausible session
+# with this workspace. Killing it early is what the cleanup line at the bottom
+# of the checklist is for.
+cat >"$WORK/bin/git" <<'EOF'
+#!/bin/sh
+sleep 300 &
+wait
+EOF
+chmod +x "$WORK/bin/git"
+
+# Three projects, so there is somewhere to move the cursor to and the read can
+# be watched happening more than once. Reads are lazy — issued on Enter into a
+# project, per tui/git.go — so each Enter is a fresh observation.
+#
+# printf rather than a heredoc, and not by preference: `<<-` strips leading
+# TABS, which is exactly the character make requires at the start of a recipe
+# line. A tab-indented heredoc here produces "missing separator" on every
+# target — silently, because nothing runs these until a human does.
+for name in alpha beta gamma; do
+	mkdir -p "$WORK/$name"
+	{
+		printf '.PHONY: hello build test lint deploy\n\n'
+		printf 'hello: ## Print a greeting\n\t@echo "hello from %s"\n\n' "$name"
+		printf 'build: ## Pretend to build\n\t@echo "built %s"\n\n' "$name"
+		printf 'test: ## Pretend to test\n\t@echo "tested %s"\n\n' "$name"
+		printf 'lint: ## Pretend to lint\n\t@echo "linted %s"\n\n' "$name"
+		printf 'deploy: ## Pretend to deploy\n\t@echo "deployed %s"\n' "$name"
+	} >"$WORK/$name/Makefile"
+done
+
+cat <<EOF
+
+Workspace: $WORK
+A shim named 'git' is first on PATH there. It never answers.
+
+Run it with:
+
+  cd $WORK && PATH="$WORK/bin:\$PATH" $MKX
+
+What to look for
+----------------
+
+  1. Press Enter on 'alpha'. The header segment reads  …  while the read is
+     in flight.
+
+     It MUST change to  git unknown  about two and a half seconds later:
+     the 2s read deadline, then up to 500ms for cmd.Wait to give up on the
+     pipe the descendant is holding. Count it — "eventually" is the defect,
+     not the fix.
+
+     If it sits on  …  and never resolves, TAE-62 is back. That is the whole
+     failure mode: the deadline fires, git is killed, and the read goes on
+     waiting on a pipe a killed process cannot close.
+
+  2. While it still reads  …  , press / and type. Filtering must respond
+     immediately, and Esc must clear it. The read is on a tea.Cmd, so a
+     read in flight has never blocked the event loop — this confirms that
+     the bound did not change it.
+
+  3. Esc back to the project list, then Enter on 'beta'. Same sequence
+     again, and the same ~2.5s. The bound is per read, not per session.
+
+  4. Esc, then Enter on 'alpha' again. The header reads  git unknown
+     immediately: the failed read is cached for the generation, so there is
+     no second wait.
+
+Delete it with:
+
+  rm -rf $WORK
+
+The sleeps the shim leaves behind exit on their own within five minutes, or:
+
+  pkill -f 'sleep 300'
+
+EOF

--- a/scripts/verify-waitdelay-guard.sh
+++ b/scripts/verify-waitdelay-guard.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Proves the bounded-read test actually fails without the fix.
+#
+# TAE-62's deliverable is a read that does NOT hang, and a green suite does not
+# demonstrate that — only that nothing hung this time. So this removes
+# cmd.WaitDelay from a throwaway copy of the repository and asserts the test
+# goes red, by name. Your working tree is never touched.
+#
+# The stronger half of the check is what must stay GREEN. The test drives two
+# shim shapes and only one of them reproduces the defect: `exec sleep` leaves no
+# descendant and is bounded by the kill alone, while a bare `sleep` leaves one
+# holding the captured stdout pipe. If the sabotage reddened both, the test
+# would be failing for some reason other than the mechanism — a broken copy, a
+# compile error, an over-tight budget — and would be worthless as evidence. So
+# the asymmetry is asserted, not just the failure.
+#
+# The pristine run comes first for the same reason. This test spawns processes
+# and measures wall-clock time; if it cannot pass in this environment before the
+# sabotage, a red afterwards says nothing about WaitDelay.
+#
+# Run via: make verify-waitdelay-guard
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PKG="./internal/adapter/gitx/"
+TARGET="internal/adapter/gitx/gitx.go"
+TEST="TestRunBoundsAKilledProcessWhoseDescendantHoldsStdout"
+
+# The sentinel comment above the assignment in run(). The sabotage deletes from
+# it through the cmd.WaitDelay line it introduces.
+SENTINEL="// waitdelay-guard:"
+
+failures=0
+
+# fresh_copy <name> — a pristine copy of the working tree, minus git and build output.
+fresh_copy() {
+	local dest="$WORK/$1"
+	mkdir -p "$dest"
+	# ./mkx, not mkx: an unanchored pattern matches every path component of
+	# that name, which would drop cmd/mkx/ along with the built binary. The
+	# gitx package would still compile without it, so the copy would look fine
+	# and the guard would go on reporting a verdict about a truncated tree.
+	tar -C "$REPO_ROOT" --exclude=.git --exclude=dist --exclude=./mkx -cf - . | tar -C "$dest" -xf -
+	echo "$dest"
+}
+
+# strip_waitdelay <dir> — delete the sentinel comment block and the assignment
+# that follows it.
+#
+# The copy must actually change, and afterwards it must contain no cmd.WaitDelay
+# at all. A sentinel that no longer matches — because the comment was reworded,
+# or run() was restructured — would otherwise leave the bound in place, the test
+# would pass, and this script would report success while checking nothing. That
+# is the exact false confidence it exists to rule out, so a no-op sabotage is a
+# failure here, not a silent skip.
+strip_waitdelay() {
+	local dir="$1"
+	local file="$dir/$TARGET"
+
+	awk -v s="$SENTINEL" '
+		index($0, s) { skip = 1; next }
+		skip && /cmd\.WaitDelay/ { skip = 0; next }
+		skip { next }
+		{ print }
+	' "$file" >"$file.tmp" || {
+		printf 'FAIL  the sabotage step itself errored\n'
+		failures=$((failures + 1))
+		return 1
+	}
+
+	if cmp -s "$file" "$file.tmp"; then
+		printf 'FAIL  the sentinel %s matched nothing in %s — this script has stopped checking\n' \
+			"$SENTINEL" "$TARGET"
+		failures=$((failures + 1))
+		rm -f "$file.tmp"
+		return 1
+	fi
+
+	mv "$file.tmp" "$file"
+
+	if grep -q 'cmd\.WaitDelay' "$file"; then
+		printf 'FAIL  %s still sets cmd.WaitDelay after the sabotage — the bound was not removed\n' "$TARGET"
+		failures=$((failures + 1))
+		return 1
+	fi
+}
+
+echo "Sabotaging a throwaway copy under $WORK"
+echo
+
+# --- 1. Pristine: the reproduction has to work here at all ------------------
+d="$(fresh_copy pristine)"
+if out="$(cd "$d" && go test -count=1 -v -run "$TEST" "$PKG" 2>&1)"; then
+	printf 'PASS  pristine copy — the bounded-read test is green before any sabotage\n'
+	printf '%s\n' "$out" | grep -E '^\s+run_bounded_test\.go' | sed 's/^[[:space:]]*/      /'
+else
+	printf 'FAIL  pristine copy — the bounded-read test does not pass before the sabotage.\n'
+	printf '      A red run after the sabotage would prove nothing about WaitDelay.\n'
+	printf '%s\n' "$out" | sed 's/^/        /'
+	failures=$((failures + 1))
+fi
+echo
+
+# --- 2. WaitDelay removed: the descendant case must go red, alone -----------
+d="$(fresh_copy strip-waitdelay)"
+if strip_waitdelay "$d"; then
+	out="$(cd "$d" && go test -count=1 -v -run "$TEST" "$PKG" 2>&1)"
+	rc=$?
+
+	if [ "$rc" -eq 0 ]; then
+		printf 'FAIL  WaitDelay removed — the suite stayed GREEN.\n'
+		printf '      The bounded-read test does not detect an unbounded read; it is not evidence.\n'
+		failures=$((failures + 1))
+	else
+		red_ok=1
+		green_ok=1
+		grep -qF -- "--- FAIL: $TEST/bare-sleep" <<<"$out" || red_ok=0
+		grep -qF -- "--- PASS: $TEST/exec-sleep" <<<"$out" || green_ok=0
+
+		if [ "$red_ok" -eq 1 ] && [ "$green_ok" -eq 1 ]; then
+			printf 'PASS  WaitDelay removed — the test discriminates\n'
+			printf '      red:   %s/bare-sleep   (a descendant holds the pipe)\n' "$TEST"
+			printf '      green: %s/exec-sleep   (nothing survives the kill)\n' "$TEST"
+			# The t.Fatalf line is printed BEFORE the --- FAIL: marker, not
+			# after it, so this looks backwards from the marker.
+			grep -B6 -F -- "--- FAIL: $TEST/bare-sleep" <<<"$out" |
+				grep -E '^\s+run_bounded_test\.go' | sed 's/^[[:space:]]*/         /'
+		else
+			[ "$red_ok" -eq 0 ] && printf 'FAIL  %s/bare-sleep did not go red; the suite failed for some other reason\n' "$TEST"
+			[ "$green_ok" -eq 0 ] && printf 'FAIL  %s/exec-sleep did not stay green; the test is not isolating the mechanism\n' "$TEST"
+			printf '%s\n' "$out" | sed 's/^/        /'
+			failures=$((failures + 1))
+		fi
+	fi
+fi
+echo
+
+if [ "$failures" -ne 0 ]; then
+	echo "$failures check(s) failed — the read bound is not proven."
+	exit 1
+fi
+
+echo "The bounded-read test goes red without WaitDelay, and only for the case that needs it."


### PR DESCRIPTION
Closes TAE-62.

`exec.CommandContext` kills git when the 2s read deadline expires, but `cmd.Run` then blocks on the captured stdout pipe for as long as any descendant of git still holds the write end — a killed parent does not close its children's copies. The header stayed on `…` indefinitely, past the deadline whose entire purpose is to prevent an unbounded read.

The fix is `cmd.WaitDelay`, set at `run()`'s single exec site.

The architect plan is on the Linear issue: [plan comment](https://linear.app/taelron/issue/TAE-62/git-read-deadline-does-not-bound-a-killed-process-whose-descendant#comment-c697211e).

## Against the acceptance criteria

**A killed read whose descendant holds stdout resolves to unknown within a bounded time.**
`cmd.WaitDelay = app.GitWaitDelay` in `gitx.run`. There is one exec site serving all three reads (`rev-parse`, `status`, `branch`), so the bound cannot land on a subset and a fourth read added later inherits it. Handovers are untouched — `git pull` and `git checkout` own a real terminal and capture nothing.

It bounds two shapes, both verified:

| shape | trigger | what returns |
|---|---|---|
| killed at the deadline, descendant survives | ctx expires | `ctxErr` = `DeadlineExceeded`, delay charged on top of the 2s |
| exits cleanly, descendant survives | `core.fsmonitor` daemon | `ctx.Err()` is nil, `exec.ErrWaitDelay`, delay is the only bound |

The second is not an `*ExitError`, so it lands in the could-not-start branch and degrades to unknown. Deliberate, and commented as such: output that arrived through a pipe closed under it may be truncated, and ADR-M003 forbids a read that cannot be trusted from reading as clean.

**Read this before assuming the second row is theoretical.** It was confirmed reachable by experiment during the build: a command that exits 0 immediately while leaving a descendant on stdout returns `exec.ErrWaitDelay` after exactly the delay, with `ctx.Err()` still `nil` — the deadline never fires, so the delay is the whole bound. That is the `core.fsmonitor` route, and it is the realistic real-world path into this defect rather than the constructed one.

**Its coverage is prose, not a test.** The subtests below reproduce the killed-at-the-deadline shape only; the clean-exit shape is covered by the comment at that branch in `gitx.go` and by nothing executable. The approved plan settled it that way deliberately. A reader deciding whether this path is protected should know it rests on a comment surviving future edits.

**The bound is stated and justified alongside the 2s deadline, in the same place.**
One grouped `const` block in `internal/app/usecases.go`: 2s deadline, 500ms delay, **2.5s worst case stated once**. Split across two files, the next reader finds one number and gets the total wrong. At most one delay is ever charged to a read — every path that can incur it is a failure path, and `RepoState` returns on the first failure rather than issuing the next command.

Half a second because waiting longer never rescues this read: the descendant holds the pipe for as long as it lives, so extra time only postpones the unknown the caller is already owed.

**A test reproduces the case and fails without the fix.**
`internal/adapter/gitx/run_bounded_test.go` (`//go:build unix`) puts a shim named `git` on PATH in both shapes — `exec sleep`, which leaves no descendant and was always bounded, and a bare `sleep`, which leaves one holding the pipe.

A test asserting that something does *not* hang passes perfectly when the reproduction quietly stops reproducing, so it also asserts the reproduction happened: `ctxErr` must be `DeadlineExceeded`, and elapsed must be at least the deadline. A shim that is not found returns in a millisecond with a nil `ctxErr` and fails both checks. `run()` goes in a goroutine so an unbounded read fails in 4.8s rather than hanging to the `go test` timeout.

**No change to the 2s deadline, no configuration surface, discovery untouched.**
`gitReadTimeout` keeps its value. Both numbers stay compile-time constants — ADR-M004 names that as the compliant shape. `make verify` passes with no rebaseline.

## Evidence

The mechanism is visible in the two timings — the second is the first plus the delay:

```
run_bounded_test.go:124: bounded: run returned after 301ms   exec-sleep  (no descendant)
run_bounded_test.go:124: bounded: run returned after 801ms   bare-sleep  (descendant holds the pipe)
```

Driven under a PTY against `make demo-hung-git`, with a `git` that never answers:

```
  +0.00s  Enter on 'alpha': read issued
  +0.02s  header reads  …  (read in flight)
  +1.28s  filter mode active — UI responsive with the read outstanding
  +2.52s  header reads  git unknown  (DEGRADED)
```

Same workspace, same driver, against a build with `cmd.WaitDelay` removed: the header still read `…` when the run ended at +7.5s, and `git unknown` never arrived.

## Verification handoff

Run top to bottom.

| # | Command | Purpose | Expected |
|---|---|---|---|
| 1 | `make build` | compiles | binary written, no output |
| 2 | `make verify-gitx` | git classifier tests plus the new bounded-read test | PASS; both subtests logged, `exec-sleep` ~300ms and `bare-sleep` ~800ms |
| 3 | `make verify-waitdelay-guard` | **new** — proves the test goes red without the fix | pristine copy green, then `bare-sleep` red **by name** while `exec-sleep` stays green |
| 4 | `make test` | full suite | all packages ok |
| 5 | `make verify` | discovery golden | PASS, and `git status` shows **no** change under `testdata/` — no rebaseline |
| 6 | `make verify-guards` then `make verify-batch-guard` | pre-existing guards still trip | each reports its sabotage red |
| 7 | `make demo-hung-git` | the user-visible half | prints a workspace path and a checklist |
| 8 | `cd <that path> && PATH="<that path>/bin:$PATH" <repo>/mkx`, then Enter on `alpha` | watch the bound | header shows `…`, then `git unknown` about 2.5s later — not never, and not 2s. Press `/` and type while it still reads `…`: filtering must respond |

Step 8 is the one that cannot be automated here, and it is the one that checks what ADR-M003 actually promises. Steps 7–8 leave a throwaway workspace behind; the checklist ends with the `rm -rf` for it.

## Notes

- `internal/adapter/makex` has the same `CommandContext` + `cmd.Output()` shape on a context with no deadline at all, and discovery runs before the TUI appears. Reported, not touched — filed as TAE-63.
- `scripts/verify-waitdelay-guard.sh` copies the tree with `--exclude=./mkx` rather than `--exclude=mkx`. The unanchored form matches every path component of that name, so it drops `cmd/mkx/` along with the built binary. The two existing guard scripts still use the unanchored form; harmless for them today, since the packages they test compile without `cmd/`.
