### PR TITLE
fix(tui): degrade the hint bar instead of letting it wrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,10 @@ jobs:
       # descendant-holds-the-pipe case goes red while the case that does not
       # need the bound stays green.
       - run: make verify-waitdelay-guard
+      # TAE-60's hint bar fit, again the same class of claim: the deliverable is
+      # a bar that does not wrap, which a green suite cannot demonstrate. This
+      # reverts renderHintBar to the naive width in a throwaway copy and fails
+      # unless the width table goes red at 79, 60 and 40 while staying green at
+      # 80 — where the bar fits even unfitted, so a sabotage that reddened it
+      # too would mean the copy was broken rather than the mechanism proven.
+      - run: make verify-hintbar-guard

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY   := mkx
 FIXTURES := testdata/fixtures
 
-.PHONY: build test verify verify-parser verify-gitx verify-tui verify-guards verify-batch-guard verify-waitdelay-guard rebaseline-golden tidy-check run demo-git demo-hung-git
+.PHONY: build test verify verify-parser verify-gitx verify-tui verify-hintbar-widths verify-guards verify-batch-guard verify-waitdelay-guard verify-hintbar-guard rebaseline-golden tidy-check run demo-git demo-hung-git
 
 build: ## Compile the mkx binary
 	go build -o $(BINARY) ./cmd/mkx
@@ -27,6 +27,14 @@ verify-gitx: ## Run the git classifier tests and the bounded-read test
 verify-tui: ## Run the TUI keymap, modal and overlay tests by name
 	go test -v -count=1 ./internal/ui/tui/
 
+verify-hintbar-widths: ## Print the hint bar at every width in the table and assert it degrades rather than wraps
+	# -v is load-bearing here, not decoration: the subtests log the bar they
+	# rendered, and `go test` discards that output on a pass. The point of this
+	# target is to be READ — the degradation has to be legible, which is not
+	# something a green tick can show. Add new hintbar_test.go tests to this
+	# list, or they run only under verify-tui.
+	go test -v -count=1 -run '^(TestHintBarDegradesAcrossTheWidthTable|TestTargetBarMatchesTheComputedTable|TestFullViewHeightIsWidthInvariant|TestALongFlashDoesNotWrapTheBar|TestAFlashClaimsWidthAheadOfTheDroppableHints|TestTheFitIsExactAtEveryWidth|TestAFlashCarryingANewlineDoesNotBecomeASecondRow|TestTargetHintBarFitsAtTheSupportedMinimum)$$' ./internal/ui/tui/
+
 verify-guards: ## Prove the golden guards fail — sabotages a throwaway copy, never this tree
 	./scripts/verify-oracle-guards.sh
 
@@ -35,6 +43,9 @@ verify-batch-guard: ## Prove the batched-input tests fail when either guard is r
 
 verify-waitdelay-guard: ## Prove the bounded-read test fails when the read bound is removed
 	./scripts/verify-waitdelay-guard.sh
+
+verify-hintbar-guard: ## Prove the width table fails when the hint bar fit is removed, and only below 80
+	./scripts/verify-hintbar-guard.sh
 
 rebaseline-golden: ## Re-anchor the golden to current behaviour — reviewed behaviour changes only
 	go test -count=1 -v -run '^TestCharacterization$$' ./internal/app/ -rebaseline

--- a/internal/ui/tui/hintbar.go
+++ b/internal/ui/tui/hintbar.go
@@ -1,0 +1,230 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gaetan-Jaminon/mkx/internal/ui/tui/styles"
+)
+
+// fitHintBar renders a view's hint entries into avail display columns on
+// exactly one line.
+//
+// The bar used to be handed to lipgloss at the terminal's width and left there.
+// lipgloss word-wraps rather than truncates, so a bar that did not fit became
+// two rows — which changes the view's rendered height and breaks
+// height-sensitive tests for reasons that look unrelated to width. That is
+// TAE-60. A bar must degrade legibly instead, and legibly means the user can
+// still see that something was dropped and still reach the full list.
+//
+// avail is the bar's content width: the terminal width less styles.HintBar's
+// Padding(0,1). Callers pass w-2; the function knows nothing about Model.
+//
+// # The claim order
+//
+// Width is claimed in this order, and each claimant only sees what the ones
+// above it left:
+//
+//  1. pinned entries — the view's exits, Esc/Back and ?/Help
+//  2. the flash — truncated with an ellipsis if it alone exceeds what remains
+//  3. droppable entries, left to right
+//  4. the +N marker, at the position of the first omitted entry
+//
+// So a long `Pull failed: <git error>` costs the user their hints rather than
+// wrapping the bar, and never costs them the ? that lists the hints again. The
+// hints are recoverable; the error text is not. That trade is why the flash
+// outranks the droppables — and it is the point at which MkX rendering the
+// flash *inside* the bar stops being incidental and becomes structural. See
+// @MkX Design Notes, "The flash message renders inside the hint bar".
+//
+// # Why the marker's cost is inside the fit
+//
+// The largest surviving-entry count is chosen exactly: every candidate below is
+// measured with its marker already in it, rather than appending the marker to a
+// set that was sized without it. Sizing first and marking after would overflow
+// the very width the fit was for.
+//
+// # The floor
+//
+// Below the width that holds the pinned set the marker yields, then every
+// entry but the last pinned one, and finally clampWidth cuts what is left. The
+// result is one line at every width, including widths the product does not
+// support — renderHintBar substitutes 80 columns below 20, matching the rest of
+// the view, so the narrow end here is a floor rather than a rendering path.
+func fitHintBar(entries []hintEntry, avail int, flash string) string {
+	if avail <= 0 {
+		// Two columns of terminal are two columns of padding: there is no
+		// content column left to degrade into.
+		return ""
+	}
+
+	// Flattened before it is measured, because lipgloss.Width reports the
+	// widest line rather than the total: a flash carrying a newline measures
+	// short, fits every candidate, and is returned still carrying it. The bar
+	// then renders on two rows at any terminal width — the same silent height
+	// change this function exists to prevent, reached through the message
+	// instead of the width.
+	//
+	// No flash source can produce one today: gitx already takes firstLine() of
+	// captured stderr, and the %q verbs elsewhere escape a newline rather than
+	// emitting it. This keeps the guarantee a property of the fit rather than
+	// of every present and future caller remembering.
+	flash = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ").Replace(flash)
+
+	if len(entries) == 0 {
+		return clampWidth(styles.Flash.Render(flash), avail)
+	}
+
+	// Candidate 1: everything, with the flash untouched. The prescribed formats
+	// are byte-identical here, and no +N token appears — which is what keeps
+	// TestHintBarsMatchTheBaselineFormats meaningful at and above 80 columns.
+	keep := make([]bool, len(entries))
+	for i := range keep {
+		keep[i] = true
+	}
+	if s, w := assembleHintBar(entries, keep, false, flash); w <= avail {
+		return s
+	}
+
+	// Something will be omitted, so a marker is now part of every candidate.
+	// The flash is truncated to what the pinned entries and that marker leave,
+	// before the droppables get to claim anything.
+	flash = clampFlash(entries, avail, flash)
+
+	var pinned, droppable []int
+	for i, e := range entries {
+		if e.pinned {
+			pinned = append(pinned, i)
+		} else {
+			droppable = append(droppable, i)
+		}
+	}
+
+	// Candidates 2..n: keep every pinned entry, and the droppables left to
+	// right, shedding one more from the right each round. Widths decrease
+	// monotonically, so the first that fits is the widest that fits.
+	for n := len(droppable) - 1; n >= 0; n-- {
+		keep = keepSet(len(entries), pinned, droppable[:n])
+		if s, w := assembleHintBar(entries, keep, true, flash); w <= avail {
+			return s
+		}
+	}
+
+	// Below that the pinned set itself no longer fits. It sheds from the left,
+	// so the last pinned entry — ?/Help, the way back to everything dropped —
+	// is the last to go. A degradation that removes the means of discovering
+	// what was removed is the wrong degradation.
+	for n := len(pinned) - 1; n >= 1; n-- {
+		keep = keepSet(len(entries), pinned[len(pinned)-n:], nil)
+		if s, w := assembleHintBar(entries, keep, true, flash); w <= avail {
+			return s
+		}
+	}
+
+	// The marker is the last thing to yield before the survivor itself: a lone
+	// `+7` says nothing a user can act on, while a lone `?/Help` does.
+	last := len(entries) - 1
+	if len(pinned) > 0 {
+		last = pinned[len(pinned)-1]
+	}
+	keep = keepSet(len(entries), []int{last}, nil)
+	if s, w := assembleHintBar(entries, keep, false, ""); w <= avail {
+		return s
+	}
+
+	// The hard clamp. One line, ending in an ellipsis, at any width at all.
+	s, _ := assembleHintBar(entries, keep, false, "")
+	return clampWidth(s, avail)
+}
+
+// keepSet builds the survivor mask for n entries from the indices that survive.
+func keepSet(n int, groups ...[]int) []bool {
+	keep := make([]bool, n)
+	for _, g := range groups {
+		for _, i := range g {
+			keep[i] = true
+		}
+	}
+	return keep
+}
+
+// assembleHintBar lays the surviving entries out in display order and returns
+// the styled bar with its display width.
+//
+// The width is measured from the unstyled text, not from the styled string:
+// lipgloss emits no escape sequences under `go test`, where there is no TTY, so
+// measuring the render would measure two different things in two contexts.
+//
+// marker asks for the +N overflow token at the position of the first omitted
+// entry — one token however many separate runs are missing, because N counts
+// entries rather than gaps.
+func assembleHintBar(entries []hintEntry, keep []bool, marker bool, flash string) (string, int) {
+	omitted := 0
+	for _, k := range keep {
+		if !k {
+			omitted++
+		}
+	}
+
+	styled := make([]string, 0, len(entries)+2)
+	plain := make([]string, 0, len(entries)+2)
+	placed := false
+
+	for i, e := range entries {
+		if keep[i] {
+			styled = append(styled, e.render())
+			plain = append(plain, e.text())
+			continue
+		}
+		if marker && !placed {
+			placed = true
+			token := overflowMarker(omitted)
+			styled = append(styled, styles.HintOverflow.Render(token))
+			plain = append(plain, token)
+		}
+	}
+
+	if flash != "" {
+		styled = append(styled, styles.Flash.Render(flash))
+		plain = append(plain, flash)
+	}
+
+	return strings.Join(styled, hintBarSep), lipgloss.Width(strings.Join(plain, hintBarSep))
+}
+
+// overflowMarker is the token standing in for the entries that did not fit.
+func overflowMarker(n int) string { return fmt.Sprintf("+%d", n) }
+
+// clampFlash truncates the flash to the columns left over once the pinned
+// entries and the overflow marker have taken theirs — step 2 of the claim
+// order, run before any droppable entry is considered.
+//
+// The marker is sized for the largest count this bar could show, so the
+// reservation can never be short by a digit. A flash with no room left is
+// dropped rather than rendered as a bare ellipsis, which would occupy a column
+// while saying nothing.
+func clampFlash(entries []hintEntry, avail int, flash string) string {
+	if flash == "" {
+		return ""
+	}
+
+	// The bar the flash is being fitted against: the marker, every pinned
+	// entry, then the flash. That is tokens+1 separators.
+	tokens := 1 // the marker
+	room := avail - lipgloss.Width(overflowMarker(len(entries)))
+	for _, e := range entries {
+		if !e.pinned {
+			continue
+		}
+		tokens++
+		room -= lipgloss.Width(e.text())
+	}
+	room -= tokens * len(hintBarSep)
+
+	if room < 1 {
+		return ""
+	}
+	return clampWidth(flash, room)
+}

--- a/internal/ui/tui/hintbar_test.go
+++ b/internal/ui/tui/hintbar_test.go
@@ -1,0 +1,417 @@
+package tui
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The width table. TAE-60's deliverable is a bar that degrades legibly instead
+// of wrapping, and "legibly" is not something a boolean captures — so every
+// subtest below logs the bar it produced. `make verify-hintbar-widths` prints
+// eight real bars to read against the plan's computed table, rather than a
+// green tick that says only that nothing crashed.
+//
+// Why these widths:
+//
+//	200  a normal terminal — degradation must never trigger here
+//	 80  the supported minimum per @UI Patterns; the target bar is 78 of 78
+//	 79  the exact boundary — one column short, the first entry drops
+//	 60  a plausible split pane
+//	 40  the width the issue names as the stress case
+//	 20  the pinned set no longer fits: Esc/Back yields, ?/Help survives
+//	 10  the marker yields; ?/Help alone
+//	  2  the hard clamp — two columns of terminal are two columns of padding
+//
+// 10 and 2 are below the 20 columns at which renderHintBar substitutes 80, so
+// they exercise fitHintBar directly. They pin the floor of the pure function
+// regardless of what the render path does with narrow terminals.
+var hintBarWidths = []int{200, 80, 79, 60, 40, 20, 10, 2}
+
+// The target view's bar at each width, exactly as the approved plan computed
+// it. Pinned because a degradation that is merely *a* degradation is not the
+// deliverable: which entries yield, in which order, and where the marker lands
+// are the product decision. A diff here is a changed decision, and should read
+// as one.
+var targetBarByWidth = map[int]string{
+	200: "↑↓/Navigate  //Search  Enter/Run  b/Branch  g/Pull  R/Readme  Esc/Back  ?/Help",
+	80:  "↑↓/Navigate  //Search  Enter/Run  b/Branch  g/Pull  R/Readme  Esc/Back  ?/Help",
+	79:  "↑↓/Navigate  //Search  Enter/Run  b/Branch  g/Pull  +1  Esc/Back  ?/Help",
+	60:  "↑↓/Navigate  //Search  Enter/Run  +3  Esc/Back  ?/Help",
+	40:  "↑↓/Navigate  +5  Esc/Back  ?/Help",
+	20:  "+7  ?/Help",
+	10:  "?/Help",
+	2:   "",
+}
+
+var overflowToken = regexp.MustCompile(`\+(\d+)`)
+
+// barAt returns k's bar, unstyled, as it reaches the screen at terminal width
+// w.
+//
+// At and above 20 columns that means the real render path, m.renderHintBar —
+// not fitHintBar behind its back. Which is load-bearing twice over: these
+// subtests then cover the wiring as well as the fit, and verify-hintbar-guard.sh
+// can revert renderHintBar in a throwaway copy and require exactly these
+// subtests to go red.
+//
+// Below 20 columns renderHintBar substitutes 80, matching the view body above
+// it, so w=10 and w=2 call the fitter directly. They pin the pure function's
+// floor rather than a rendering path the product has.
+func barAt(k keymap, w int, flash string) string {
+	if w < 20 {
+		return ansi.Strip(fitHintBar(k.barEntries(), w-2, flash))
+	}
+
+	m := testModel()
+	m.width = w
+	m.flash = flash
+	// Trimmed of styles.HintBar's Padding(0,1) and of the Width(w) fill. A
+	// wrapped bar keeps its newline through this, which is the point.
+	return strings.TrimSpace(ansi.Strip(m.renderHintBar(k)))
+}
+
+// TestHintBarDegradesAcrossTheWidthTable is the issue's core claim, asserted at
+// every width for both views.
+func TestHintBarDegradesAcrossTheWidthTable(t *testing.T) {
+	for name, k := range viewKeymaps() {
+		entries := k.barEntries()
+
+		for _, w := range hintBarWidths {
+			t.Run(fmt.Sprintf("%s/w=%d", name, w), func(t *testing.T) {
+				bar := barAt(k, w, "")
+				t.Logf("w=%-3d %2d cols │%s│", w, lipgloss.Width(bar), bar)
+
+				assertOneLine(t, bar)
+				assertFitsWithin(t, bar, w)
+				assertHelpSurvives(t, bar, w)
+				assertMarkerCountIsHonest(t, bar, entries, w)
+				assertPinnedYieldLast(t, bar, entries)
+				assertDroppablesGoRightToLeft(t, bar, entries)
+			})
+		}
+	}
+}
+
+// TestTargetBarMatchesTheComputedTable pins the exact output the plan derived.
+func TestTargetBarMatchesTheComputedTable(t *testing.T) {
+	k := targetKeymap()
+
+	for _, w := range hintBarWidths {
+		t.Run(fmt.Sprintf("w=%d", w), func(t *testing.T) {
+			want := targetBarByWidth[w]
+			got := barAt(k, w, "")
+			t.Logf("w=%-3d %2d cols │%s│", w, lipgloss.Width(got), got)
+
+			if got != want {
+				t.Errorf("the target bar degraded differently from the approved plan\n"+
+					"got  %q\nwant %q\n"+
+					"If the change to the entries or to the fit order is deliberate, "+
+					"recompute this row rather than relaxing the assertion.", got, want)
+			}
+		})
+	}
+}
+
+// TestFullViewHeightIsWidthInvariant is what the issue is actually about.
+//
+// A wrapped bar still renders. The failure is silent, and it surfaces as a view
+// that is one row taller than every height-sensitive test expects — for a
+// reason no line in those failures points at. So the assertion is not "the bar
+// is one line" but "the view is the same number of lines at every width", which
+// is the property the rest of the suite depends on.
+func TestFullViewHeightIsWidthInvariant(t *testing.T) {
+	cases := map[string]func(Model) Model{
+		"targets":  func(m Model) Model { m.view = viewTargets; return m },
+		"projects": func(m Model) Model { m.view = viewProjects; m.projectCursor = 0; return m },
+	}
+
+	for name, setView := range cases {
+		t.Run(name, func(t *testing.T) {
+			var want int
+			for _, w := range hintBarWidths {
+				m := setView(testModel())
+				m.width = w
+				m.height = 24
+
+				got := strings.Count(m.View(), "\n") + 1
+				t.Logf("w=%-3d %d lines", w, got)
+
+				if want == 0 {
+					want = got
+					continue
+				}
+				if got != want {
+					t.Errorf("the view rendered %d lines at width %d and %d lines at width %d;\n"+
+						"a width-dependent height means something wrapped, and every "+
+						"height-sensitive test in this package is calibrated against the "+
+						"width-independent count", got, w, want, hintBarWidths[0])
+				}
+			}
+		})
+	}
+}
+
+// A long flash is the live half of TAE-60, not the latent half.
+//
+// The issue was filed against a bar that would wrap once another binding was
+// added. But renderHintBar appended the flash before applying the width, and
+// two flash sources are unbounded — runFailedMsg's msg.err.Error() and
+// gitPullFinishedMsg's "Pull failed: %v". A git error long enough wraps the bar
+// on a terminal far wider than 80, today, with no new binding involved.
+//
+// 116 columns is where the falsification in the issue description was measured.
+func TestALongFlashDoesNotWrapTheBar(t *testing.T) {
+	// A real git failure, not a synthetic one: this is the shape that reaches
+	// m.flash through "Pull failed: %v".
+	const gitErr = "Pull failed: fatal: unable to access " +
+		"'https://github.example.com/org/repository.git/': " +
+		"Could not resolve host: github.example.com"
+
+	for _, w := range []int{116, 80, 60} {
+		t.Run(fmt.Sprintf("w=%d", w), func(t *testing.T) {
+			m := testModel()
+			m.width = w
+			m.flash = gitErr
+
+			bar := ansi.Strip(m.renderHintBar(targetKeymap()))
+			t.Logf("w=%-3d %2d cols │%s│", w, lipgloss.Width(bar), bar)
+
+			if n := strings.Count(bar, "\n"); n != 0 {
+				t.Errorf("a %d-column flash wrapped the bar to %d lines at width %d",
+					lipgloss.Width(gitErr), n+1, w)
+			}
+			if got := lipgloss.Width(bar); got > w {
+				t.Errorf("the bar is %d columns wide at width %d", got, w)
+			}
+			// The flash outranks the hints, but never the escape hatch: the
+			// user must still be able to reach the list the error cost them.
+			if !strings.Contains(bar, "?/Help") {
+				t.Errorf("a long flash pushed ?/Help out of the bar: %q", bar)
+			}
+			// And the error is still readable — truncated, not omitted.
+			if !strings.Contains(bar, "Pull failed:") {
+				t.Errorf("the flash itself was dropped rather than truncated: %q", bar)
+			}
+		})
+	}
+}
+
+// A flash carrying a newline must not become a second row.
+//
+// lipgloss.Width reports the widest line, not the total, so an unflattened
+// multi-line flash measures short, fits every candidate untouched, and is
+// returned with the newline still in it — a two-row bar on a 200-column
+// terminal. Same silent height change as the wrapping this issue was filed
+// about, reached through the message rather than the width.
+//
+// Nothing produces one today: gitx takes firstLine() of captured stderr and the
+// %q verbs elsewhere escape newlines. This pins the guarantee to the fit rather
+// than to every present and future flash source.
+func TestAFlashCarryingANewlineDoesNotBecomeASecondRow(t *testing.T) {
+	for _, flash := range []string{"first\nsecond", "first\r\nsecond", "trailing\n"} {
+		t.Run(fmt.Sprintf("%q", flash), func(t *testing.T) {
+			m := testModel()
+			m.width = 200
+			m.height = 24
+			m.flash = flash
+
+			bar := ansi.Strip(m.renderHintBar(targetKeymap()))
+			t.Logf("│%s│", bar)
+
+			if n := strings.Count(bar, "\n"); n != 0 {
+				t.Errorf("a flash carrying a newline rendered the bar on %d rows", n+1)
+			}
+
+			plain := testModel()
+			plain.width, plain.height = 200, 24
+			if got, want := strings.Count(m.View(), "\n"), strings.Count(plain.View(), "\n"); got != want {
+				t.Errorf("the view is %d lines with the flash and %d without it", got+1, want+1)
+			}
+		})
+	}
+}
+
+// The flash claims width after the pinned entries and before the droppable
+// ones. A flash too long to sit beside the hints costs the hints, not the bar's
+// single line and not the exits.
+//
+// Measured at 116 columns rather than 80: at the supported minimum the target
+// bar is already 78 of 78, so *any* flash costs a hint there and the two halves
+// of this claim could not be told apart. 116 is where a run receipt is free and
+// a git error is not.
+func TestAFlashClaimsWidthAheadOfTheDroppableHints(t *testing.T) {
+	k := targetKeymap()
+
+	short := barAt(k, 116, "✓ 2s")
+	long := barAt(k, 116, strings.Repeat("x", 60))
+	t.Logf("short flash │%s│", short)
+	t.Logf("long flash  │%s│", long)
+
+	if strings.Contains(short, "+") {
+		t.Errorf("a four-column flash forced a degradation at 116 columns: %q", short)
+	}
+	if !strings.Contains(long, "+") {
+		t.Errorf("a sixty-column flash cost the bar nothing at 116 columns: %q", long)
+	}
+	for _, want := range []string{"Esc/Back", "?/Help"} {
+		if !strings.Contains(long, want) {
+			t.Errorf("a long flash dropped the pinned %s: %q", want, long)
+		}
+	}
+}
+
+// The fit is exact rather than conservative: at every width the bar is as full
+// as it can be. One more entry would not fit — checked by rendering the bar one
+// column narrower and requiring it to lose something.
+func TestTheFitIsExactAtEveryWidth(t *testing.T) {
+	for name, k := range viewKeymaps() {
+		for _, w := range hintBarWidths {
+			if w <= 2 {
+				continue // below the clamp there is nothing left to under-fill
+			}
+			t.Run(fmt.Sprintf("%s/w=%d", name, w), func(t *testing.T) {
+				bar := barAt(k, w, "")
+				wider := barAt(k, w+1, "")
+
+				if lipgloss.Width(wider) > w-2 && lipgloss.Width(bar) == lipgloss.Width(wider) {
+					t.Errorf("the bar at %d columns is the same as at %d, "+
+						"but the wider one does not fit here: %q", w, w+1, bar)
+				}
+			})
+		}
+	}
+}
+
+// ------------------------------------------------------------ the assertions
+
+func assertOneLine(t *testing.T, bar string) {
+	t.Helper()
+	if n := strings.Count(bar, "\n"); n != 0 {
+		t.Errorf("the bar rendered on %d lines, want 1:\n%s", n+1, bar)
+	}
+}
+
+func assertFitsWithin(t *testing.T, bar string, w int) {
+	t.Helper()
+	// w-2 is the content width: styles.HintBar carries Padding(0,1).
+	if got := lipgloss.Width(bar); got > w-2 {
+		t.Errorf("the bar is %d columns wide, and a %d-column terminal leaves %d "+
+			"once the bar's padding is taken: %q", got, w, w-2, bar)
+	}
+}
+
+func assertHelpSurvives(t *testing.T, bar string, w int) {
+	t.Helper()
+	if w <= 2 {
+		// The floor. Two columns of terminal are two columns of padding, so
+		// there is no content column for ?/Help to survive into. What is
+		// asserted here is that the bar yields the columns rather than
+		// overflowing them.
+		if bar != "" {
+			t.Errorf("the bar rendered %q with no content columns available", bar)
+		}
+		return
+	}
+	if !strings.HasPrefix("?/Help", strings.TrimSuffix(bar, "…")) && !strings.Contains(bar, "?/Help") {
+		t.Errorf("?/Help did not survive the degradation at width %d: %q\n"+
+			"It is the escape hatch — a degradation that removes the way to discover "+
+			"what was removed is the wrong degradation.", w, bar)
+	}
+}
+
+// The marker must count what is actually missing. A marker that drifts from the
+// truth is worse than no marker: it is a number the user cannot act on.
+func assertMarkerCountIsHonest(t *testing.T, bar string, entries []hintEntry, w int) {
+	t.Helper()
+
+	missing := 0
+	for _, e := range entries {
+		if !strings.Contains(bar, e.text()) {
+			missing++
+		}
+	}
+
+	m := overflowToken.FindStringSubmatch(bar)
+	if m == nil {
+		if missing == 0 || bar == "" {
+			return
+		}
+		// A missing marker is legal in exactly one place: the floor, where the
+		// marker and the last survivor cannot both fit. The marker yields
+		// there because a lone `+7` tells the user nothing they can act on
+		// while a lone `?/Help` does. Anywhere it would have fitted, its
+		// absence is the silent degradation this issue exists to remove — so
+		// the excuse is checked rather than assumed.
+		token := fmt.Sprintf("+%d", missing)
+		if cost := lipgloss.Width(bar) + len("  ") + len(token); cost <= w-2 {
+			t.Errorf("%d entries were dropped with no +N marker to say so, "+
+				"and %s would have fitted (%d of %d columns): %q",
+				missing, token, cost, w-2, bar)
+		}
+		return
+	}
+
+	got, err := strconv.Atoi(m[1])
+	if err != nil {
+		t.Fatalf("unparsable overflow marker %q in %q", m[0], bar)
+	}
+	if got != missing {
+		t.Errorf("the bar says +%d but %d entries are actually missing: %q", got, missing, bar)
+	}
+}
+
+// Pinned entries yield only once every droppable one has. Deriving priority
+// from bar order would drop Esc/Back off the target view at 79 columns while
+// keeping R/Readme; this is the assertion that would catch that.
+func assertPinnedYieldLast(t *testing.T, bar string, entries []hintEntry) {
+	t.Helper()
+	if bar == "" {
+		return
+	}
+
+	droppableSurvives := false
+	for _, e := range entries {
+		if !e.pinned && strings.Contains(bar, e.text()) {
+			droppableSurvives = true
+		}
+	}
+	if !droppableSurvives {
+		return
+	}
+	for _, e := range entries {
+		if e.pinned && !strings.Contains(bar, e.text()) {
+			t.Errorf("the pinned %s was dropped while droppable entries survived: %q",
+				e.text(), bar)
+		}
+	}
+}
+
+// Droppable entries yield right to left, so what survives is always a prefix of
+// the declared order — the order @UI Patterns prescribes, read left to right.
+func assertDroppablesGoRightToLeft(t *testing.T, bar string, entries []hintEntry) {
+	t.Helper()
+	if bar == "" {
+		return
+	}
+
+	dropped := false
+	for _, e := range entries {
+		if e.pinned {
+			continue
+		}
+		if strings.Contains(bar, e.text()) {
+			if dropped {
+				t.Errorf("%s survived while an entry to its left did not; "+
+					"droppable entries yield right to left: %q", e.text(), bar)
+			}
+			continue
+		}
+		dropped = true
+	}
+}

--- a/internal/ui/tui/keymap.go
+++ b/internal/ui/tui/keymap.go
@@ -29,6 +29,20 @@ type binding struct {
 	// inBar marks a binding that appears in the hint bar. Help-only bindings
 	// (q/Quit in the target view) clear it.
 	inBar bool
+	// barPinned marks a bar entry the fitter may never drop when the bar does
+	// not fit: the view's exits, Esc/Back and ?/Help. Everything else yields to
+	// width, left to right, behind a +N marker.
+	//
+	// The zero value is droppable, so a binding added later degrades by default
+	// rather than silently claiming survival — the same reasoning opensTextSink
+	// carries above.
+	//
+	// Two tiers rather than a priority int: the data supports "the user can
+	// always leave and can always reach the full list" and nothing finer.
+	// Priority is not derivable from bar order either — dropping right to left
+	// would take Esc/Back off the target view at 79 columns while keeping
+	// R/Readme. See hintbar.go.
+	barPinned bool
 	// opensTextSink marks the one kind of binding a batch may fire: one whose
 	// whole effect is to switch the view into a mode that captures keystrokes
 	// as text. Today that is `/` and nothing else. The zero value is false, so
@@ -49,13 +63,38 @@ type binding struct {
 // bar, its help overlay and its key dispatch.
 type keymap []binding
 
-// hintBar renders the inBar bindings as styled "display/label" pairs separated
-// by two spaces, per the @UI Patterns hint bar format.
+// hintEntry is one deduped hint bar entry, in display order. It is what the
+// bar is assembled from, so the fitter can drop and count entries rather than
+// slicing a finished string — see fitHintBar in hintbar.go.
+type hintEntry struct {
+	display string
+	label   string
+	pinned  bool
+}
+
+// text is the entry as the user reads it, unstyled: "↑↓/Navigate". Widths are
+// measured from this rather than from render(), so a measurement is the same
+// under a TTY and under `go test`, where lipgloss emits no escapes.
+func (e hintEntry) text() string { return e.display + "/" + e.label }
+
+// render is the entry as the bar shows it: the key styled, the /label dimmed.
+func (e hintEntry) render() string {
+	return styles.HintKey.Render(e.display) + styles.HintAction.Render("/"+e.label)
+}
+
+// hintBarSep separates hint bar entries, per the @UI Patterns format.
+const hintBarSep = "  "
+
+// barEntries returns the inBar bindings as hint entries, in declaration order.
 //
 // Entries are deduped on display+label: ↑/k and ↓/j are four keys and two
 // handlers, but one visible ↑↓/Navigate.
-func (k keymap) hintBar() string {
-	var parts []string
+//
+// hintBar and the width fitter both build on this, so there is one dedup path
+// and the full-width bar and a degraded one can never disagree about what the
+// view's entries are.
+func (k keymap) barEntries() []hintEntry {
+	var entries []hintEntry
 	seen := make(map[string]bool)
 
 	for _, b := range k {
@@ -67,10 +106,28 @@ func (k keymap) hintBar() string {
 			continue
 		}
 		seen[key] = true
-		parts = append(parts, styles.HintKey.Render(b.display)+styles.HintAction.Render("/"+b.label))
+		entries = append(entries, hintEntry{display: b.display, label: b.label, pinned: b.barPinned})
 	}
 
-	return strings.Join(parts, "  ")
+	return entries
+}
+
+// hintBar renders every bar entry as styled "display/label" pairs separated by
+// two spaces, per the @UI Patterns hint bar format.
+//
+// This is the bar at its natural width, with nothing dropped — the prescribed
+// format, which TestHintBarsMatchTheBaselineFormats pins byte for byte. What
+// actually reaches the screen goes through fitHintBar, which may drop entries
+// when the terminal is too narrow to hold them all.
+func (k keymap) hintBar() string {
+	entries := k.barEntries()
+
+	parts := make([]string, 0, len(entries))
+	for _, e := range entries {
+		parts = append(parts, e.render())
+	}
+
+	return strings.Join(parts, hintBarSep)
 }
 
 // helpRows renders every binding — not just the ones in the hint bar — as

--- a/internal/ui/tui/keymap_views.go
+++ b/internal/ui/tui/keymap_views.go
@@ -73,8 +73,11 @@ func projectKeymap() keymap {
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				return m, tea.Quit
 			}},
+		// The root view's only pinned entry. There is no Esc/Back to pin —
+		// q/Quit sits where the patterns put Esc, and it is help-recoverable
+		// like every other droppable entry.
 		{keys: []string{"?"}, display: "?", label: "Help",
-			help: "Keys available in this view", inBar: true,
+			help: "Keys available in this view", inBar: true, barPinned: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				return m.showModal(modalHelp, "Help", "Projects", modalInput{}, helpKeymap()), nil
 			}},
@@ -159,8 +162,11 @@ func targetKeymap() keymap {
 				}
 				return m, viewReadme(m.app.ReadmePath(m.rootCtx, proj))
 			}},
+		// Pinned: the way out of the view. Dropping it right-to-left by bar
+		// order would take it at 79 columns while keeping R/Readme, which is
+		// why the pin is a declared property rather than derived from position.
 		{keys: []string{"esc"}, display: "Esc", label: "Back",
-			help: "Back to the project list", inBar: true,
+			help: "Back to the project list", inBar: true, barPinned: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				// Esc clears whenever there is anything to clear — filter mode
 				// active, or mode closed by Enter with the text still in
@@ -181,8 +187,10 @@ func targetKeymap() keymap {
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				return m, tea.Quit
 			}},
+		// Pinned, and the last entry to yield anywhere: it is how the user
+		// finds out what the marker counted.
 		{keys: []string{"?"}, display: "?", label: "Help",
-			help: "Keys available in this view", inBar: true,
+			help: "Keys available in this view", inBar: true, barPinned: true,
 			handler: func(m Model, _ string) (Model, tea.Cmd) {
 				proj, _ := m.currentProject()
 				return m.showModal(modalHelp, "Help", proj.Name, modalInput{}, helpKeymap()), nil

--- a/internal/ui/tui/model.go
+++ b/internal/ui/tui/model.go
@@ -364,14 +364,32 @@ func (m Model) View() string {
 }
 
 // renderHintBar renders a view's keymap as the bottom bar, with any flash
-// message appended. The key/Action formatting lives on keymap.hintBar; this
-// function only owns the flash and the bar's width.
+// message alongside it, on exactly one line at any terminal width.
+//
+// This function owns only the width. What survives a width too small to hold
+// everything, and in what order, is fitHintBar's — see hintbar.go for the claim
+// order and why the flash outranks the droppable hints.
+//
+// The sub-20 substitution matches renderProjectList and renderTargetList: below
+// that width the whole view renders at 80 columns and the terminal wraps it.
+// Without it the bar alone would degrade while the body above it did not, so
+// the view would disagree with itself about how wide it is.
 func (m Model) renderHintBar(k keymap) string {
-	bar := k.hintBar()
-	if m.flash != "" {
-		bar += "  " + styles.Flash.Render(m.flash)
+	w := m.width
+	if w < 20 {
+		w = 80
 	}
-	return styles.HintBar.Width(m.width).Render(bar)
+
+	// hintbar-guard: these two lines are the fix. verify-hintbar-guard.sh
+	// reverts them, in a throwaway copy, to the naive
+	// `styles.HintBar.Width(w).Render(bar)` over an untruncated bar, and
+	// requires the width table to go red at 79, 60 and 40 while staying green
+	// at 80. Rewording this comment without updating that script makes the
+	// script stop checking, and it fails loudly rather than passing quietly.
+	//
+	// w-2 is HintBar's Padding(0,1): the content width, not the terminal's.
+	bar := fitHintBar(k.barEntries(), w-2, m.flash)
+	return styles.HintBar.Width(w).Render(bar)
 }
 
 // renderHeader renders the top bar: the title on the left, the position

--- a/internal/ui/tui/model_test.go
+++ b/internal/ui/tui/model_test.go
@@ -132,35 +132,55 @@ func TestHintBarsMatchTheBaselineFormats(t *testing.T) {
 	}
 }
 
-// TestTargetHintBarFitsOnOneLine is a width guard, not a formatting
-// preference.
+// TestTargetHintBarFitsAtTheSupportedMinimum replaces TAE-59's
+// TestTargetHintBarFitsOnOneLine. The ≤78 assertion is the same; what it means
+// is not.
 //
-// styles.HintBar is Width(80) with Padding(0,1), so it has 78 content columns —
-// and it is fixed at 80 regardless of the terminal, so the ceiling holds on a
-// 200-column terminal too. With b/Branch the target bar is exactly 78 of 78. At
-// 79 lipgloss word-wraps rather than truncating, the bar silently becomes two
-// rows, and every height-sensitive test in this suite breaks with no line in
-// the failure pointing at the cause.
+// It used to guard a broken render: the bar was handed to lipgloss at the
+// terminal's width, lipgloss word-wrapped rather than truncating, and a
+// seventy-ninth column silently made the bar two rows — breaking every
+// height-sensitive test in this package for a reason none of those failures
+// named. TAE-60 removed that: fitHintBar degrades instead, so no bar can wrap
+// at any width.
 //
-// So the next binding added to this view fails here instead, loudly, saying
-// what to do about it. The underlying fixed width is TAE-60's to fix; this test
-// is what TAE-60 replaces, not what it deletes.
-func TestTargetHintBarFitsOnOneLine(t *testing.T) {
-	const barContentWidth = 78
+// So this now guards a product decision. 78 is the target view's content width
+// at 80 columns, the supported minimum per @UI Patterns, and the bar is exactly
+// 78 of 78. The first view that exceeds it starts degrading *at the supported
+// minimum* — showing a +N marker on a standard terminal. That is a choice, and
+// it should be made deliberately rather than discovered by a user on an
+// 80-column terminal.
+//
+// "TAE-60 makes room" is not what happened. Degradation is now safe; the
+// ceiling is unchanged.
+func TestTargetHintBarFitsAtTheSupportedMinimum(t *testing.T) {
+	const barContentWidth = 78 // 80 columns less styles.HintBar's Padding(0,1)
 
 	if w := lipgloss.Width(ansi.Strip(targetKeymap().hintBar())); w > barContentWidth {
-		t.Errorf("the target hint bar is %d columns wide, and styles.HintBar has only %d; "+
-			"it will wrap to a second line. Shorten a label, drop a binding from the bar, "+
-			"or fix the fixed width (TAE-60) — do not just raise this number",
+		t.Errorf("the target hint bar is %d columns wide and only %d fit at the "+
+			"supported minimum of 80, so it now degrades to a +N marker there.\n"+
+			"Three legitimate answers: shorten a label, mark the new binding help-only "+
+			"(inBar: false), or accept degradation at 80 and edit this test on purpose. "+
+			"Raising the number without choosing one of those is the silent option.",
 			w, barContentWidth)
 	}
 
-	// The claim itself, through the real style rather than through arithmetic
-	// about it: one rendered line at 80 columns.
+	// The claim itself, through the real render rather than through arithmetic
+	// about it: at 80 columns the whole prescribed bar is present, on one line,
+	// with no marker.
 	m := testModel()
 	m.width = 80
-	if n := strings.Count(m.renderHintBar(targetKeymap()), "\n"); n != 0 {
+	bar := ansi.Strip(m.renderHintBar(targetKeymap()))
+
+	if n := strings.Count(bar, "\n"); n != 0 {
 		t.Errorf("the target hint bar rendered on %d lines at width 80, want 1", n+1)
+	}
+	if strings.Contains(bar, "+") {
+		t.Errorf("the bar carries an overflow marker at the supported minimum: %q", bar)
+	}
+	// Trimmed of styles.HintBar's one column of padding on each side.
+	if got, want := strings.TrimSpace(bar), ansi.Strip(targetKeymap().hintBar()); got != want {
+		t.Errorf("the rendered bar at 80 columns is not the prescribed format\n"+
+			"got  %q\nwant %q", got, want)
 	}
 }
 

--- a/internal/ui/tui/styles/styles.go
+++ b/internal/ui/tui/styles/styles.go
@@ -116,6 +116,15 @@ var (
 	HintAction = lipgloss.NewStyle().
 			Foreground(colorDimmed)
 
+	// HintOverflow is the +N marker standing in for the hint entries a narrow
+	// terminal could not fit. Yellow and bold, per the colour conventions'
+	// "attention required": the marker exists to be noticed, and a dimmed
+	// marker in a dimmed bar would be exactly the silent degradation TAE-60
+	// forbids.
+	HintOverflow = lipgloss.NewStyle().
+			Foreground(colorYellow).
+			Bold(true)
+
 	// HintBar is the bottom bar itself.
 	HintBar = lipgloss.NewStyle().
 		Background(lipgloss.Color("235")).

--- a/scripts/verify-hintbar-guard.sh
+++ b/scripts/verify-hintbar-guard.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# Proves the hint bar width table actually fails without the fix.
+#
+# TAE-60's deliverable is a bar that does NOT wrap, and a green suite does not
+# demonstrate that — only that nothing wrapped this time. So this reverts
+# renderHintBar in a throwaway copy of the repository to what it was before the
+# fix, and asserts the width table goes red, by subtest name. Your working tree
+# is never touched.
+#
+# The stronger half of the check is what must stay GREEN. The naive render is
+# not wrong at every width: at 80 columns the target bar is exactly 78 of 78
+# content columns, so it fits there even unfitted, and w=80 must keep passing.
+# If the sabotage reddened every width, the table would be failing for some
+# reason other than the mechanism — a broken copy, a compile error, a bad
+# sentinel — and would be worthless as evidence. So the asymmetry is asserted,
+# not just the failure.
+#
+# That asymmetry is also the shape of the bug itself. It was invisible at the
+# supported minimum and appeared one column below it, which is why it survived
+# to be filed as a latent issue rather than a live one.
+#
+# The pristine run comes first for the same reason: if the table cannot pass in
+# this environment before the sabotage, a red afterwards says nothing.
+#
+# Run via: make verify-hintbar-guard
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PKG="./internal/ui/tui/"
+TARGET="internal/ui/tui/model.go"
+TEST="TestHintBarDegradesAcrossTheWidthTable"
+
+# The sentinel comment inside renderHintBar. The sabotage replaces everything
+# from it through the return that follows.
+SENTINEL="// hintbar-guard:"
+
+# The subtests that must go red, and the one that must not. Both views' bars fit
+# at 80 unfitted; only the target view is narrow enough to wrap below it, and it
+# is the view the issue was measured on.
+RED_SUBTESTS=("targets/w=79" "targets/w=60" "targets/w=40")
+GREEN_SUBTESTS=("targets/w=80" "projects/w=80")
+
+failures=0
+
+# fresh_copy <name> — a pristine copy of the working tree, minus git and build output.
+fresh_copy() {
+	local dest="$WORK/$1"
+	mkdir -p "$dest"
+	# ./mkx, not mkx: an unanchored pattern matches every path component of
+	# that name, which would drop cmd/mkx/ along with the built binary.
+	tar -C "$REPO_ROOT" --exclude=.git --exclude=dist --exclude=./mkx -cf - . | tar -C "$dest" -xf -
+	echo "$dest"
+}
+
+# unfit_the_bar <dir> — put renderHintBar back to the pre-TAE-60 body: the whole
+# bar assembled at its natural width, the flash appended untruncated, and the
+# result handed to lipgloss at the terminal's width to word-wrap.
+#
+# The copy must actually change. A sentinel that no longer matches — because the
+# comment was reworded, or renderHintBar was restructured — would otherwise
+# leave the fix in place, the table would pass, and this script would report
+# success while checking nothing. That is the exact false confidence it exists
+# to rule out, so a no-op sabotage is a failure here, not a silent skip.
+unfit_the_bar() {
+	local dir="$1"
+	local file="$dir/$TARGET"
+
+	cat >"$WORK/naive.go.frag" <<'FRAG'
+	bar := k.hintBar()
+	if m.flash != "" {
+		bar += "  " + styles.Flash.Render(m.flash)
+	}
+	return styles.HintBar.Width(w).Render(bar)
+FRAG
+
+	awk -v s="$SENTINEL" -v frag="$WORK/naive.go.frag" '
+		index($0, s) {
+			skip = 1
+			while ((getline line < frag) > 0) print line
+			close(frag)
+			next
+		}
+		skip && /return styles\.HintBar/ { skip = 0; next }
+		skip { next }
+		{ print }
+	' "$file" >"$file.tmp" || {
+		printf 'FAIL  the sabotage step itself errored\n'
+		failures=$((failures + 1))
+		return 1
+	}
+
+	if cmp -s "$file" "$file.tmp"; then
+		printf 'FAIL  the sentinel %s matched nothing in %s — this script has stopped checking\n' \
+			"$SENTINEL" "$TARGET"
+		failures=$((failures + 1))
+		rm -f "$file.tmp"
+		return 1
+	fi
+
+	mv "$file.tmp" "$file"
+
+	# The call, not the name: renderHintBar's doc comment names fitHintBar to
+	# point at where the claim order lives, and that comment sits above the
+	# sentinel and survives the sabotage.
+	if grep -qF 'fitHintBar(' "$file"; then
+		printf 'FAIL  %s still calls fitHintBar after the sabotage — the fit was not removed\n' "$TARGET"
+		failures=$((failures + 1))
+		return 1
+	fi
+}
+
+echo "Sabotaging a throwaway copy under $WORK"
+echo
+
+# --- 1. Pristine: the table has to pass here at all -------------------------
+d="$(fresh_copy pristine)"
+if out="$(cd "$d" && go test -count=1 -v -run "$TEST" "$PKG" 2>&1)"; then
+	printf 'PASS  pristine copy — the width table is green before any sabotage\n'
+	printf '%s\n' "$out" | grep -E 'hintbar_test\.go:[0-9]+: w=' | sed 's/^[[:space:]]*/      /'
+else
+	printf 'FAIL  pristine copy — the width table does not pass before the sabotage.\n'
+	printf '      A red run afterwards would prove nothing about the fit.\n'
+	printf '%s\n' "$out" | sed 's/^/        /'
+	failures=$((failures + 1))
+fi
+echo
+
+# --- 2. The fit removed: the narrow widths must go red, and only those -------
+d="$(fresh_copy unfit)"
+if unfit_the_bar "$d"; then
+	out="$(cd "$d" && go test -count=1 -v -run "$TEST" "$PKG" 2>&1)"
+	rc=$?
+
+	if [ "$rc" -eq 0 ]; then
+		printf 'FAIL  the fit removed — the suite stayed GREEN.\n'
+		printf '      The width table does not detect a wrapping hint bar; it is not evidence.\n'
+		failures=$((failures + 1))
+	else
+		bad=0
+		for sub in "${RED_SUBTESTS[@]}"; do
+			if grep -qF -- "--- FAIL: $TEST/$sub" <<<"$out"; then
+				printf '      red:   %s\n' "$sub"
+			else
+				printf 'FAIL  %s did not go red; the table does not catch a wrapped bar there\n' "$sub"
+				bad=1
+			fi
+		done
+		for sub in "${GREEN_SUBTESTS[@]}"; do
+			if grep -qF -- "--- PASS: $TEST/$sub" <<<"$out"; then
+				printf '      green: %s\n' "$sub"
+			else
+				printf 'FAIL  %s did not stay green; the sabotage reddened a width that fits\n' "$sub"
+				printf '      unfitted, so the table is not isolating the mechanism.\n'
+				bad=1
+			fi
+		done
+
+		if [ "$bad" -eq 0 ]; then
+			printf 'PASS  the fit removed — the table discriminates\n'
+			# What w=79 actually said. `go test` groups every --- FAIL: marker
+			# after all the log output, so this reads the subtest's own === RUN
+			# block rather than the lines around its marker.
+			printf '%s\n' "$out" |
+				awk -v r="=== RUN   $TEST/targets/w=79" '
+					$0 == r { on = 1; next }
+					on && /^=== / { exit }
+					on && /hintbar_test\.go:[0-9]+:/ { print "         " $0 }
+				' | sed 's/         [[:space:]]*/         /'
+		else
+			printf '%s\n' "$out" | grep -E '^\s+--- (PASS|FAIL): ' | sed 's/^/        /'
+			failures=$((failures + 1))
+		fi
+	fi
+fi
+echo
+
+if [ "$failures" -ne 0 ]; then
+	echo "$failures check(s) failed — the hint bar fit is not proven."
+	exit 1
+fi
+
+echo "The width table goes red without the fit, and stays green where the bar fits without it."


### PR DESCRIPTION
Closes TAE-60.

## The defect is currently reachable, not only latent

The issue was filed against a bar that *would* wrap once another binding was added: the target view's bar is 78 of 78 content columns at 80, the supported minimum per @UI Patterns, so the next binding crosses it.

That is only half of it. **The same line carries a defect that is live today.** `renderHintBar` appended the flash message into the bar *before* applying the width, untruncated, and two flash sources are unbounded — `msg.err.Error()` (`runFailedMsg`) and `Pull failed: %v` (`gitPullFinishedMsg`). A long git error wraps the bar **at 116 columns, on current `main`, with no new binding involved**. The issue as filed described only the latent half; this PR fixes both.

A wrapped bar still renders, so the failure is silent: it changes the view's rendered height and breaks height-sensitive tests for reasons that look unrelated to width.

## What was built

`fitHintBar` (new `internal/ui/tui/hintbar.go`) claims the available width in order — **pinned entries, the flash, droppable entries left to right, then a `+N` marker** at the position of the first omitted entry. A long error therefore costs the user their hints rather than the bar's single line, and never costs them the `?` that lists the hints again. The marker's cost is inside the fit rather than appended after it, so no width is under-filled.

Priority is a declared `barPinned` flag on `binding`, not derived from bar order: right-to-left would drop `Esc/Back` off the target view at 79 columns while keeping `R/Readme`, and pinning "the last two" fixes that view while breaking the projects view, whose `q/Quit` would survive over `Enter/Targets`. The zero value is droppable, so a binding added later degrades by default. Set on `esc` and `?` (targets) and `?` (projects) — nowhere else.

Computed and asserted output for the target view:

```
≥80  ↑↓/Navigate  //Search  Enter/Run  b/Branch  g/Pull  R/Readme  Esc/Back  ?/Help   (78)
 79  ↑↓/Navigate  //Search  Enter/Run  b/Branch  g/Pull  +1  Esc/Back  ?/Help         (72)
 60  ↑↓/Navigate  //Search  Enter/Run  +3  Esc/Back  ?/Help                           (54)
 40  ↑↓/Navigate  +5  Esc/Back  ?/Help                                                (33)
 20  +7  ?/Help                                                                       (10)
 10  ?/Help                                                                            (6)
```

`+N` renders in a new `styles.HintOverflow` (yellow, bold): a dimmed marker in a dimmed bar would be exactly the silent degradation the issue forbids.

### A hole in this issue's own guarantee, found in review

Not an unrelated extra. `fitHintBar` exists to guarantee one line, and it would have shipped unable to keep that guarantee.

`lipgloss.Width` reports the *widest line*, not the total. So a flash carrying a newline measures short, fits every candidate untouched, and is returned still carrying it — a two-row bar at any terminal width, including 200 columns. Same silent height change the issue was filed about, reached through the message instead of the width, in the very function written to prevent it.

It is latent only by coincidence, not by design: nothing produces a multi-line flash today because `gitx` happens to apply `firstLine()` to captured stderr and the `%q` verbs elsewhere happen to escape newlines. Neither is a decision this function made or can rely on — a future error source that skips `firstLine()` reintroduces TAE-60 with nothing failing to say so. The flash is now flattened before it is measured, so the guarantee belongs to the fit rather than to every present and future caller remembering.

Surfaced by the in-session `code-reviewer` pass, confirmed against the live render (the view came out 24 lines instead of 23), and the new test verified to go red with the flattening removed.

### Deliberately unchanged

- **Modal hint bars keep `clampWidth` and do not route through the fitter.** A modal bar carries two entries, both structural, so dropping one loses `Esc/Cancel` entirely — worse than an ellipsis. `buildModalBox` is untouched.
- **Below 20 columns** the bar substitutes 80 like `renderProjectList`/`renderTargetList` already do, so the bar and the body cannot disagree about how wide the view is. Out of contract, unchanged.
- **`hintBar()`'s output is byte-identical**, so `TestHintBarsMatchTheBaselineFormats` and the modal bar tests stay green unedited. Discovery is untouched; `make verify` needs no rebaseline.

### Acceptance criteria

| AC | Where |
|---|---|
| Degrades legibly; no wrap, no silent height change, at any width | `fitHintBar`; `TestHintBarDegradesAcrossTheWidthTable`, `TestFullViewHeightIsWidthInvariant` |
| The plan states what is dropped | `barPinned` two-tier drop, left-to-right, behind `+N` |
| Correct at 80×24, above it, and degrading below | the width table, 200 → 2 |
| TAE-59's test replaced, not deleted, still failing loudly | `TestTargetHintBarFitsOnOneLine` → `TestTargetHintBarFitsAtTheSupportedMinimum` |

### Deviation on record

MkX renders the flash *inside* the hint bar, where @UI Patterns places it just above. Pre-existing; **not changed here**. TAE-60's width claim order makes the deviation structural rather than incidental — see @MkX Design Notes, "The flash message renders inside the hint bar" (amended 2026-08-02). Moving it out would add a line to every view's height and is a separate decision.

## Verification handoff

Run top to bottom.

| # | Command | Purpose | Expected |
|---|---|---|---|
| 1 | `make build` | compiles | binary written |
| 2 | `make verify-hintbar-widths` *(new)* | the width table, `-v`, printing the rendered bar at each width | PASS; read the eight bars against the table above |
| 3 | `make verify-tui` | full TUI suite incl. height invariance and the 80-column design guard | PASS |
| 4 | `make verify-hintbar-guard` *(new)* | proves the table goes red without the fix, and only where it should | PASS, reporting red at 79/60/40 and green at 80 |
| 5 | `make test` | full suite | PASS |
| 6 | `make verify` | golden oracle — discovery, not rendering | PASS **with no rebaseline**; movement here is a real signal |
| 7 | `make verify-guards && make verify-batch-guard && make verify-waitdelay-guard` | existing guards unaffected | PASS |
| 8 | `make run`, then narrow the pane 120 → 80 → 60 → 40 by hand | the bar degrades live; `?` still opens help listing everything dropped | one line at every width; `+N` visible in yellow below 80 |

**Step 8 is outstanding.** Steps 1–7 have been run and pass; step 8 has not, and it cannot be run headlessly — it needs a real terminal being resized by a person.

It is not a duplicate of the automated checks. Steps 1–7 establish that the bar is *correct*: one line, within the width, the right entries dropped, an honest count. Step 8 establishes that it is **legible** — that a user meeting a `+N` at 60 columns can tell what happened and knows `?` will show them what is missing, and that yellow reads as attention against the dimmed bar rather than disappearing into it. No assertion in this PR checks that, which is also why the width subtests `t.Logf` the rendered string rather than only asserting on it.

So this PR should not be read as fully verified until step 8 is done. Correctness is evidenced; legibility is not yet.

`scripts/verify-hintbar-guard.sh` is wired into CI's `guards` job in this PR, so it runs on every push rather than only when someone remembers.

The architect plan lives on the Linear issue: https://linear.app/taelron/issue/TAE-60/hint-bar-wraps-instead-of-degrading-when-it-cannot-fit
