### PR TITLE
docs: point the active milestone at M3 — Loose ends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Linear is canonical. Everything below points at Linear rather than restating it;
 
 **Phase 1 — minimum viable implementation.** Per @AI Workflow, Phase 1 ends with v1.0: an installable, usable artifact delivering the core value the spec promises. The phase is gated on that deliverable, not on a schedule.
 
-**Active milestone: M2 — Target filtering and branch switching** (in progress) — [MkX project in Linear](https://linear.app/taelron/project/mkx-7067f8030ab4).
+**Active milestone: M3 — Loose ends** (in progress) — [MkX project in Linear](https://linear.app/taelron/project/mkx-7067f8030ab4).
 
 This file is updated when the active milestone changes, typically once per milestone closure.
 


### PR DESCRIPTION
M2 — Target filtering and branch switching closed with TAE-60. M3 — Loose ends is now in progress.

The milestone names match the MkX project in Linear, which is canonical: https://linear.app/taelron/project/mkx-7067f8030ab4

## Why it matters

This is the line a session reads at start to orient itself. Stale by one milestone, it points a fresh session at a closed milestone and sends it looking for issues that are already done.

## Verification handoff

No runnable verification surface — this is a one-line documentation pointer with no code, test or build impact. The check is by eye:

| # | Command | Purpose | Expected |
|---|---|---|---|
| 1 | `git diff main` | the whole change | one line: M2 → M3 — Loose ends, nothing else |
| 2 | — | the name matches Linear | milestone reads exactly `M3 — Loose ends` in the project linked above |

CI still runs build and test on this branch; both are unaffected by a documentation-only change.
