### PR TITLE
build: add an install target with an overridable PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,31 @@
 BINARY   := mkx
 FIXTURES := testdata/fixtures
 
-.PHONY: build test verify verify-parser verify-gitx verify-tui verify-hintbar-widths verify-guards verify-batch-guard verify-waitdelay-guard verify-hintbar-guard rebaseline-golden tidy-check run demo-git demo-hung-git
+# Install location. Both are overridable, so no machine's own layout is baked
+# into the repo: `make install PREFIX=/usr/local` or `make install BINDIR=/tmp/x`.
+# ?= rather than := so BINDIR keeps tracking PREFIX when only PREFIX is given.
+PREFIX ?= $(HOME)/.local
+BINDIR ?= $(PREFIX)/bin
+
+.PHONY: build install test verify verify-parser verify-gitx verify-tui verify-hintbar-widths verify-guards verify-batch-guard verify-waitdelay-guard verify-hintbar-guard rebaseline-golden tidy-check run demo-git demo-hung-git
 
 build: ## Compile the mkx binary
 	go build -o $(BINARY) ./cmd/mkx
+
+install: build ## Install the binary to $(BINDIR) — override PREFIX or BINDIR to put it elsewhere
+	# Depends on build rather than copying whatever ./mkx happens to be. An
+	# install target that ships a stale binary is worse than none: the copy on
+	# PATH is the one that gets run, and nothing about it says how old it is.
+	install -d $(BINDIR)
+	install -m 0755 $(BINARY) $(BINDIR)/$(BINARY)
+	@echo "installed $(BINDIR)/$(BINARY)"
+	@case ":$$PATH:" in \
+		*":$(BINDIR):"*) ;; \
+		*) echo "warning: $(BINDIR) is not on your PATH, so \`$(BINARY)\` will not resolve to it" ;; \
+	esac
+	@command -v $(BINARY) >/dev/null 2>&1 && \
+		[ "$$(command -v $(BINARY))" != "$(BINDIR)/$(BINARY)" ] && \
+		echo "warning: \`$(BINARY)\` resolves to $$(command -v $(BINARY)), not the copy just installed" || true
 
 test: ## Run the full test suite
 	go test ./...


### PR DESCRIPTION
`make build` writes `./mkx` inside the repo and nothing put it on PATH, so installing was a manual copy.

That had already gone wrong on at least one machine: a binary from **May** was sitting in `~/.local/bin`, months behind `main`, and — being on PATH — it was silently the one that ran whenever `mkx` was typed outside the checkout. It predated the M1 restructure entirely.

## What it does

```make
PREFIX ?= $(HOME)/.local
BINDIR ?= $(PREFIX)/bin
```

Both `?=`, so either can be overridden and no machine's own layout is baked into the repo:

```
make install                      # -> $HOME/.local/bin/mkx
make install PREFIX=/usr/local    # -> /usr/local/bin/mkx
make install BINDIR=/tmp/x        # -> /tmp/x/mkx
```

`BINDIR` is `?=` rather than `:=` so it keeps tracking `PREFIX` when only `PREFIX` is given.

**It depends on `build`** rather than copying whatever `./mkx` happens to be. An install target that ships a stale binary is worse than none: the copy on PATH is the one that gets run, and nothing about it says how old it is — which is exactly how the May binary survived.

**Two warnings, neither fatal:** `BINDIR` not on PATH, and `mkx` resolving to some other copy than the one just installed. A silent install into a directory the shell never searches looks identical to a working one right up until behaviour seems not to have changed.

## Verification handoff

| # | Command | Purpose | Expected |
|---|---|---|---|
| 1 | `make install BINDIR=/tmp/mkx-install-check` | install to a throwaway directory, leaving any real install untouched | builds, then `installed /tmp/mkx-install-check/mkx` |
| 2 | `ls -l /tmp/mkx-install-check/mkx` | the binary landed, executable | mode `-rwxr-xr-x` |
| 3 | — | the two warnings fire | step 1 warns that the directory is not on PATH, and that `mkx` resolves elsewhere |
| 4 | `make -n install` | the default target expands correctly without running | destination is `$HOME/.local/bin/mkx` |
| 5 | `make install` | the real install | binary replaced; no warnings, since that directory is on PATH |
| 6 | `mkx --version 2>/dev/null; which mkx` | the installed copy is the one that resolves | resolves to `$HOME/.local/bin/mkx` |
| 7 | `make test && make verify` | nothing else moved | PASS, no rebaseline |

Steps 1–4 and 7 have been run and pass. Steps 5–6 deliberately have not: they overwrite the binary on PATH, which is the maintainer's call, not a check to run on their behalf.

`rm -rf /tmp/mkx-install-check` afterwards.