### PR TITLE
build: install from a published release by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,35 @@ FIXTURES := testdata/fixtures
 PREFIX ?= $(HOME)/.local
 BINDIR ?= $(PREFIX)/bin
 
-.PHONY: build install test verify verify-parser verify-gitx verify-tui verify-hintbar-widths verify-guards verify-batch-guard verify-waitdelay-guard verify-hintbar-guard rebaseline-golden tidy-check run demo-git demo-hung-git
+# Which published release `install` fetches, and from where. VERSION=latest
+# follows the newest tag; pin it (VERSION=v0.5.0) to install a specific one.
+REPO    ?= Taelron/MKX
+VERSION ?= latest
+
+.PHONY: build install install-source check-install-path test verify verify-parser verify-gitx verify-tui verify-hintbar-widths verify-guards verify-batch-guard verify-waitdelay-guard verify-hintbar-guard rebaseline-golden tidy-check run demo-git demo-hung-git
 
 build: ## Compile the mkx binary
 	go build -o $(BINARY) ./cmd/mkx
 
-install: build ## Install the binary to $(BINDIR) — override PREFIX or BINDIR to put it elsewhere
-	# Depends on build rather than copying whatever ./mkx happens to be. An
-	# install target that ships a stale binary is worse than none: the copy on
-	# PATH is the one that gets run, and nothing about it says how old it is.
-	install -d $(BINDIR)
-	install -m 0755 $(BINARY) $(BINDIR)/$(BINARY)
-	@echo "installed $(BINDIR)/$(BINARY)"
+install: ## Install a published release binary from GitHub — VERSION=vX.Y.Z to pin, or use install-source
+	@tmp=$$(mktemp -d); \
+	 trap 'rm -rf "$$tmp"' EXIT; \
+	 REPO=$(REPO) BINARY=$(BINARY) ./scripts/fetch-release.sh $(VERSION) "$$tmp" && \
+	 install -d $(BINDIR) && \
+	 install -m 0755 "$$tmp/$(BINARY)" $(BINDIR)/$(BINARY) && \
+	 echo "installed $(BINDIR)/$(BINARY) from release $(VERSION)"
+	@$(MAKE) --no-print-directory check-install-path
+
+install-source: build ## Install the binary built from this checkout, rather than a published release
+	@install -d $(BINDIR)
+	@install -m 0755 $(BINARY) $(BINDIR)/$(BINARY)
+	@echo "installed $(BINDIR)/$(BINARY) from this checkout ($$(git rev-parse --short HEAD 2>/dev/null || echo 'no git'))"
+	@$(MAKE) --no-print-directory check-install-path
+
+# Shared by both install paths: a binary that landed somewhere the shell never
+# searches, or that is shadowed by another copy, looks identical to a working
+# install right up until behaviour seems not to have changed.
+check-install-path:
 	@case ":$$PATH:" in \
 		*":$(BINDIR):"*) ;; \
 		*) echo "warning: $(BINDIR) is not on your PATH, so \`$(BINARY)\` will not resolve to it" ;; \

--- a/scripts/fetch-release.sh
+++ b/scripts/fetch-release.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Downloads a published mkx release archive, verifies its checksum, and leaves
+# the extracted binary in a directory the caller names.
+#
+# It does not install anything. `make install` owns where the binary goes and
+# owns the PATH warnings; this script owns "get a trustworthy binary onto this
+# machine", which is the part with a network in it.
+#
+# Usage: scripts/fetch-release.sh <version|latest> <outdir>
+#
+# The checksum step is not decoration. This writes a binary that a later step
+# puts on PATH, so an archive that arrives corrupted or substituted must fail
+# loudly here rather than become the thing the user runs. goreleaser publishes
+# checksums.txt beside the archives for exactly this.
+
+set -euo pipefail
+
+VERSION="${1:?usage: fetch-release.sh <version|latest> <outdir>}"
+OUTDIR="${2:?usage: fetch-release.sh <version|latest> <outdir>}"
+REPO="${REPO:-Taelron/MKX}"
+BINARY="${BINARY:-mkx}"
+
+# goreleaser names archives {project}_{Os}_{Arch}. uname's spelling is not
+# goreleaser's, so both axes are mapped rather than passed through — and an
+# unmapped value is an error, not a guess at a URL that will 404 later with a
+# less useful message.
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$os" in
+linux | darwin) ;;
+*)
+	echo "fetch-release: no published build for OS '$os' — build from source with 'make install-source'" >&2
+	exit 1
+	;;
+esac
+
+case "$(uname -m)" in
+x86_64 | amd64) arch="amd64" ;;
+aarch64 | arm64) arch="arm64" ;;
+*)
+	echo "fetch-release: no published build for architecture '$(uname -m)' — build from source with 'make install-source'" >&2
+	exit 1
+	;;
+esac
+
+archive="${BINARY}_${os}_${arch}.tar.gz"
+
+if [ "$VERSION" = "latest" ]; then
+	base="https://github.com/$REPO/releases/latest/download"
+else
+	base="https://github.com/$REPO/releases/download/$VERSION"
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+echo "fetching $archive from $REPO ($VERSION)" >&2
+
+# --fail so an HTML 404 page is an error rather than a file that fails to
+# extract two steps later; -L because the download endpoint redirects.
+for f in "$archive" checksums.txt; do
+	if ! curl -fsSL -o "$work/$f" "$base/$f"; then
+		echo "fetch-release: could not download $f from $base" >&2
+		echo "              check that release '$VERSION' exists and publishes $archive" >&2
+		exit 1
+	fi
+done
+
+# --ignore-missing: checksums.txt covers every platform's archive, and only one
+# of them is here. Without it sha256sum fails on the archives it cannot find and
+# the real result is lost in the noise.
+(cd "$work" && sha256sum --ignore-missing --check --status checksums.txt) || {
+	echo "fetch-release: checksum verification FAILED for $archive" >&2
+	echo "              the download does not match the published checksum; not installing it" >&2
+	exit 1
+}
+echo "checksum verified" >&2
+
+tar -C "$work" -xzf "$work/$archive"
+if [ ! -f "$work/$BINARY" ]; then
+	echo "fetch-release: $archive did not contain a '$BINARY' binary" >&2
+	exit 1
+fi
+
+mkdir -p "$OUTDIR"
+mv "$work/$BINARY" "$OUTDIR/$BINARY"
+chmod 0755 "$OUTDIR/$BINARY"
+
+# Whether the release is behind the checkout the user is standing in.
+#
+# This is the case that made the target worth guarding: a repository can sit
+# many merged commits ahead of its newest tag, and then installing "the latest
+# release" hands back something older than the source in the current directory.
+# It is a legitimate thing to want; it is never a legitimate thing to get by
+# accident, because a binary on PATH does not say how old it is.
+if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
+	tag="$VERSION"
+	if [ "$tag" = "latest" ]; then
+		tag="$(git tag --sort=-creatordate | head -1 || true)"
+	fi
+	if [ -n "$tag" ] && git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+		if ! git merge-base --is-ancestor HEAD "refs/tags/$tag" 2>/dev/null; then
+			behind="$(git rev-list --count "refs/tags/$tag"..HEAD 2>/dev/null || echo "?")"
+			echo >&2
+			echo "warning: this checkout is $behind commits ahead of $tag." >&2
+			echo "         You are installing a binary OLDER than the source you are standing in." >&2
+			echo "         'make install-source' builds and installs this checkout instead." >&2
+			echo >&2
+		fi
+	fi
+fi


### PR DESCRIPTION
`make install` built from the checkout. That's right for a maintainer standing in the repo and wrong as the default for *installing the tool*: it needs a Go toolchain, and it produces a binary that no published artifact corresponds to.

`install` now fetches the release archive for the host's OS and architecture, verifies it against the published `checksums.txt`, and installs that.

```
make install                     # newest release
make install VERSION=v0.5.0      # pinned
make install BINDIR=/tmp/x       # anywhere
make install-source              # the old behaviour: build this checkout
```

`REPO ?= Taelron/MKX` is overridable for a fork.

## Read this before merging

**`latest` is v0.5.0, from 2026-05-21.** `main` is 57 commits past it — see TAE-70. So on merge, `make install` installs May's code by default, in a tree carrying all of M1, M2 and M3.

The target says so rather than doing it quietly:

```
warning: this checkout is 57 commits ahead of v0.5.0.
         You are installing a binary OLDER than the source you are standing in.
         'make install-source' builds and installs this checkout instead.
```

That is real output from running it, not an illustration. Wanting an older release is legitimate; getting one by accident is not, because a binary on PATH does not say how old it is.

**This PR is arguably ordered after TAE-70.** It is correct on its own terms and the warning makes the surprise impossible, but the default only becomes the *good* default once a release exists that isn't three milestones stale. Merging first is defensible; doing it knowingly is the point.

## Checksum verification

The archive is checked against `checksums.txt` before anything is installed, with `--ignore-missing` because that file covers every platform and only one archive is present.

This is a control, so it was tested by breaking it rather than by watching it pass: corrupting the archive after download, in a throwaway copy of the script, exits 1 and writes nothing to the output directory.

## Other behaviour

- Unsupported OS/arch fails naming the unsupported value and pointing at `install-source`, instead of composing a URL that 404s later with a worse message.
- A missing release fails with the version and the expected asset name.
- The PATH warnings moved into `check-install-path`, shared by both install paths.
- `fetch-release.sh` only downloads, verifies and extracts. Where the binary goes stays in the Makefile.

## Verification handoff

| # | Command | Purpose | Expected |
|---|---|---|---|
| 1 | `make install BINDIR=/tmp/mkx-rel` | the default path, into a throwaway dir | downloads, `checksum verified`, and the ahead-of-release warning fires |
| 2 | `ls -l /tmp/mkx-rel/mkx` | the release binary landed | ~10.5 MB — v0.5.0, notably smaller than a current build |
| 3 | `make install VERSION=v99.0.0 BINDIR=/tmp/mkx-rel` | a release that does not exist | fails, names the version and the asset; make exits non-zero |
| 4 | `make install-source BINDIR=/tmp/mkx-src` | the previous behaviour still works | builds, installs, prints the short SHA |
| 5 | `ls -l /tmp/mkx-src/mkx` | current code | ~14.3 MB, larger than step 2's |
| 6 | `make test && make verify` | nothing else moved | PASS, no rebaseline |

Steps 1–6 have been run and pass. `rm -rf /tmp/mkx-rel /tmp/mkx-src` afterwards.

Not run: `make install` against a real PATH directory, since that would replace the maintainer's working binary with v0.5.0 — which is the whole subject of the warning above.